### PR TITLE
allow customizing currency symbol

### DIFF
--- a/CurrencyText.podspec
+++ b/CurrencyText.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "CurrencyText"
-  s.version      = "2.0.0"
+  s.version      = "2.0.1"
   s.summary      = "Currency text formatter that fits your UITextField subclass."
 
   s.homepage     = "https://github.com/marinofelipe/CurrencyText"

--- a/Example/CurrencyTextDemo/ViewController.swift
+++ b/Example/CurrencyTextDemo/ViewController.swift
@@ -28,6 +28,7 @@ class ViewController: UIViewController {
             $0.currency = .euro
             $0.locale = CurrencyLocale.frenchFrance
             $0.hasDecimals = false
+            $0.currencySymbol = "💶"
         }
         
         textFieldDelegate = CurrencyUITextFieldDelegate(formatter: currencyFormatter)

--- a/Example/CurrencyTextDemoTests/CurrencyFormatterTests.swift
+++ b/Example/CurrencyTextDemoTests/CurrencyFormatterTests.swift
@@ -57,6 +57,16 @@ class CurrencyFormatterTests: XCTestCase {
         
         formatter.hasGroupingSeparator = false
         XCTAssertEqual(formatter.numberFormatter.usesGroupingSeparator, false)
+        
+        formatter.currencySymbol = "%"
+        formatter.showCurrencySymbol = false
+        XCTAssertEqual(formatter.showCurrencySymbol, false)
+        XCTAssertEqual(formatter.numberFormatter.currencySymbol, "")
+        
+        formatter.showCurrencySymbol = true
+        formatter.currencySymbol = "%"
+        XCTAssertEqual(formatter.showCurrencySymbol, true)
+        XCTAssertEqual(formatter.numberFormatter.currencySymbol, "%")
     }
     
     func testMinAndMaxValues() {

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ let formatter = CurrencyFormatter {
   $0.currencySymbol = "💶"
 }
 
-let formattedString = formatter.string(from: 100000000) //💶 99;99;99
+let formattedString = formatter.string(from: 100000000) //💶99;99;99
 ```
 
 <a name="delegate"/>
@@ -164,9 +164,8 @@ The following properties are available:
 |-------------------------------|---------------------------------------|--------------------------------------------|
 | locale                        | `LocaleConvertible`                   | Locale of the currency                     |
 | currency                      | `Currency`                            | Currency used to format                    |                                                                     
-| currencySymbol                | `String`                              | formatter currency symbol      |
-
-| showCurrencySymbol            | `Bool`                                | Show currency symbol          |                                                                       
+| currencySymbol                | `String`                              | String shown as currency symbol            |
+| showCurrencySymbol            | `Bool`                                | Show/hide currency symbol                  |                                                                       
 | minValue                      | `Double?`                             | The lowest number allowed as input         |                                                            
 | maxValue                      | `Double?`                             | The highest number allowed as input        |
 | decimalDigits                 | `Int`                                 | The number of decimal digits shown         |                

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/marinofelipe/CurrencyText.svg?branch=master)](https://travis-ci.org/marinofelipe/CurrencyText)
 [![Coverage Status](https://coveralls.io/repos/github/marinofelipe/CurrencyText/badge.svg?branch=master)](https://coveralls.io/github/marinofelipe/CurrencyText?branch=master)
 <a href="https://swift.org"><img src="https://img.shields.io/badge/Swift-4.2-orange.svg?style=flat" alt="Swift" /></a>
-[![CocoaPods Compatible](https://img.shields.io/badge/pod-v2.0.0-blue.svg)](https://cocoapods.org/pods/CurrencyText)
+[![CocoaPods Compatible](https://img.shields.io/badge/pod-v2.0.1-blue.svg)](https://cocoapods.org/pods/CurrencyText)
 [![Platform](https://img.shields.io/cocoapods/p/CurrencyText.svg?style=flat)]()
 [![Twitter](https://img.shields.io/badge/twitter-@_marinofelipe-blue.svg?style=flat)](https://twitter.com/_marinofelipe)
 
@@ -127,7 +127,7 @@ let formatter = CurrencyFormatter {
   $0.maxValue = 999999
   $0.groupingSize = 2
   $0.groupingSeparator = ";"
-  $0.currencySymbol = 💶
+  $0.currencySymbol = "💶"
 }
 
 let formattedString = formatter.string(from: 100000000) //💶 99;99;99
@@ -164,7 +164,9 @@ The following properties are available:
 |-------------------------------|---------------------------------------|--------------------------------------------|
 | locale                        | `LocaleConvertible`                   | Locale of the currency                     |
 | currency                      | `Currency`                            | Currency used to format                    |                                                                     
-| currencySymbol                | `String`                              | Returns the formatter currency symbol      |                                                                       
+| currencySymbol                | `String`                              | formatter currency symbol      |
+
+| showCurrencySymbol            | `Bool`                                | Show currency symbol          |                                                                       
 | minValue                      | `Double?`                             | The lowest number allowed as input         |                                                            
 | maxValue                      | `Double?`                             | The highest number allowed as input        |
 | decimalDigits                 | `Int`                                 | The number of decimal digits shown         |                
@@ -207,7 +209,7 @@ $ sudo gem install cocoapods
 
 To integrate CurrencyText into your Xcode project using CocoaPods, specify it in your `Podfile`:
 
-**Tested with `pod --version`: `2.0.0`**
+**Tested with `pod --version`: `2.0.1`**
 
 ```ruby
 # Podfile

--- a/Sources/Formatter/CurrencyFormatter.swift
+++ b/Sources/Formatter/CurrencyFormatter.swift
@@ -12,7 +12,7 @@ public protocol CurrencyFormatterProtocol {
     var maxValue: Double? { get set }
     var minValue: Double? { get set }
     var initialText: String { get }
-    var currencySymbol: String { get }
+    var currencySymbol: String { get set }
     
     func string(from double: Double?) -> String?
     func unformatted(string: String) -> String?
@@ -41,8 +41,23 @@ public class CurrencyFormatter: CurrencyFormatterProtocol {
         get { return Currency(rawValue: numberFormatter.currencyCode) ?? .dollar }
     }
     
-    /// Returns the currency symbol
+    /// Define if currency symbol should be presented or not.
+    /// Note: when set to false the current currency symbol is removed
+    public var showCurrencySymbol: Bool = true {
+        didSet {
+            numberFormatter.currencySymbol = showCurrencySymbol ? numberFormatter.currencySymbol : ""
+        }
+    }
+    
+    /// The currency's symbol.
+    /// Can be used to read or set a custom symbol.
+    /// Note: showCurrencySymbol must be set to true for
+    /// the currencySymbol to be correctly changed.
     public var currencySymbol: String {
+        set {
+            guard showCurrencySymbol else { return }
+            numberFormatter.currencySymbol = newValue
+        }
         get { return numberFormatter.currencySymbol }
     }
     


### PR DESCRIPTION
### Why?
To allow changing the currency symbol.

### Changes
- Currency symbol can be set.
- Adds a Bool to show/hide currency symbol.

### Tests 
Add unit tests to guarantee behavior.

### Issue - #35