### PR TITLE
Input negative value

### DIFF
--- a/CurrencyText.podspec
+++ b/CurrencyText.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "CurrencyText"
-  s.version      = "2.0.1"
+  s.version      = "2.0.2"
   s.summary      = "Currency text formatter that fits your UITextField subclass."
 
   s.homepage     = "https://github.com/marinofelipe/CurrencyText"

--- a/Example/CurrencyTextDemo/ViewController.swift
+++ b/Example/CurrencyTextDemo/ViewController.swift
@@ -24,7 +24,7 @@ class ViewController: UIViewController {
     private func setupTextFieldWithCurrencyDelegate() {
         let currencyFormatter = CurrencyFormatter {
             $0.maxValue = 1000000
-            $0.minValue = 3
+            $0.minValue = -1000000
             $0.currency = .euro
             $0.locale = CurrencyLocale.frenchFrance
             $0.hasDecimals = false
@@ -35,7 +35,7 @@ class ViewController: UIViewController {
         textFieldDelegate.clearsWhenValueIsZero = true
         
         textField.delegate = textFieldDelegate
-        textField.keyboardType = .numberPad
+        textField.keyboardType = .numbersAndPunctuation
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {

--- a/Example/CurrencyTextDemoTests/CurrencyFormatterTests.swift
+++ b/Example/CurrencyTextDemoTests/CurrencyFormatterTests.swift
@@ -90,6 +90,13 @@ class CurrencyFormatterTests: XCTestCase {
         
         formattedString = formatter.string(from: 1)
         XCTAssertEqual(formattedString, "€10.00")
+        
+        formatter.minValue = -351
+        formattedString = formatter.string(from: -24)
+        XCTAssertEqual(formattedString, "-€24.00")
+        
+        formattedString = formatter.string(from: -400)
+        XCTAssertEqual(formattedString, "-€351.00")
     }
     
     func testFormatting() {

--- a/Example/CurrencyTextDemoTests/CurrencyTextFieldDelegateTests.swift
+++ b/Example/CurrencyTextDemoTests/CurrencyTextFieldDelegateTests.swift
@@ -109,25 +109,35 @@ class CurrencyTextFieldDelegateTests: XCTestCase {
     
     func testAddingNegativeSymbol() {
         // testing with numeric pad
-        delegate.textField(textField, shouldChangeCharactersIn: NSRange(location: textField.textLength, length: 0), replacementString: "-")
+        delegate.textField(textField, shouldChangeCharactersIn: NSRange(location: textField.textLength, length: 0), replacementString: .negativeSymbol)
         
         XCTAssertEqual(textField.text, "", "after first input the text should be correctly formated")
         
         // testing with numbersAndPunctuation pad
         textField.keyboardType = .numbersAndPunctuation
-        delegate.textField(textField, shouldChangeCharactersIn: NSRange(location: textField.textLength, length: 0), replacementString: "-")
-        XCTAssertEqual(textField.text, "-", "after first input the text should be correctly formated")
+        delegate.textField(textField, shouldChangeCharactersIn: NSRange(location: textField.textLength, length: 0), replacementString: .negativeSymbol)
+        XCTAssertEqual(textField.text, .negativeSymbol, "after first input the text should be correctly formated")
         
         delegate.textField(textField, shouldChangeCharactersIn: NSRange(location: textField.textLength, length: 0), replacementString: "3451")
-        XCTAssertEqual(textField.text, "-" + formatter.currencySymbol + "34.51")
+        XCTAssertEqual(textField.text, .negativeSymbol + formatter.currencySymbol + "34.51")
         
         //delete negative symbol
         textField.sendDeleteKeyboardAction(at: 0)
         XCTAssertEqual(textField.text, formatter.currencySymbol + "34.51")
         
         //try to add negative symbol to non negative value
-        delegate.textField(textField, shouldChangeCharactersIn: NSRange(location: 0, length: 0), replacementString: "-")
-        XCTAssertEqual(textField.text, "-" + formatter.currencySymbol + "34.51")
+        delegate.textField(textField, shouldChangeCharactersIn: NSRange(location: 0, length: 0), replacementString: .negativeSymbol)
+        XCTAssertEqual(textField.text, .negativeSymbol + formatter.currencySymbol + "34.51")
+        
+        // add negative symbol with range selected - should be added when range contains first index
+        textField.sendDeleteKeyboardAction(at: 0)
+        delegate.textField(textField, shouldChangeCharactersIn: NSRange(location: 0, length: 3), replacementString: .negativeSymbol)
+        XCTAssertEqual(textField.text, .negativeSymbol + formatter.currencySymbol + "34.51")
+        
+        // add negative symbol with range selected - should not be added when range does contains first index
+        textField.sendDeleteKeyboardAction(at: 0)
+        delegate.textField(textField, shouldChangeCharactersIn: NSRange(location: 1, length: 2), replacementString: .negativeSymbol)
+        XCTAssertEqual(textField.text, formatter.currencySymbol + "34.51")
     }
     
     func testFormatAfterFirstNumber() {

--- a/Example/CurrencyTextDemoTests/CurrencyTextFieldDelegateTests.swift
+++ b/Example/CurrencyTextDemoTests/CurrencyTextFieldDelegateTests.swift
@@ -106,6 +106,30 @@ class CurrencyTextFieldDelegateTests: XCTestCase {
     }
 
     // MARK: input/paste
+    
+    func testAddingNegativeSymbol() {
+        // testing with numeric pad
+        delegate.textField(textField, shouldChangeCharactersIn: NSRange(location: textField.textLength, length: 0), replacementString: "-")
+        
+        XCTAssertEqual(textField.text, "", "after first input the text should be correctly formated")
+        
+        // testing with numbersAndPunctuation pad
+        textField.keyboardType = .numbersAndPunctuation
+        delegate.textField(textField, shouldChangeCharactersIn: NSRange(location: textField.textLength, length: 0), replacementString: "-")
+        XCTAssertEqual(textField.text, "-", "after first input the text should be correctly formated")
+        
+        delegate.textField(textField, shouldChangeCharactersIn: NSRange(location: textField.textLength, length: 0), replacementString: "3451")
+        XCTAssertEqual(textField.text, "-" + formatter.currencySymbol + "34.51")
+        
+        //delete negative symbol
+        textField.sendDeleteKeyboardAction(at: 0)
+        XCTAssertEqual(textField.text, formatter.currencySymbol + "34.51")
+        
+        //try to add negative symbol to non negative value
+        delegate.textField(textField, shouldChangeCharactersIn: NSRange(location: 0, length: 0), replacementString: "-")
+        XCTAssertEqual(textField.text, "-" + formatter.currencySymbol + "34.51")
+    }
+    
     func testFormatAfterFirstNumber() {
         delegate.textField(textField, shouldChangeCharactersIn: NSRange(location: textField.textLength, length: 0), replacementString: "1")
 

--- a/Example/CurrencyTextDemoTests/UITextField.swift
+++ b/Example/CurrencyTextDemoTests/UITextField.swift
@@ -14,7 +14,7 @@ extension UITextField {
         return text?.count ?? 0
     }
     
-    func sendDeleteKeyboardAction() {
-        let _ = delegate?.textField?(self, shouldChangeCharactersIn: NSRange(location: textLength, length: 1), replacementString: "")
+    func sendDeleteKeyboardAction(at location: Int? = nil) {
+        let _ = delegate?.textField?(self, shouldChangeCharactersIn: NSRange(location: location ?? textLength, length: 1), replacementString: "")
     }
 }

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Just by setting a currency text field delegate object to your text field, with g
 <a name="negative"/>
 
 ### Allowing users to input `negative values`
-It's possible to allow users to input negative values. For it just set the keyboardType to .numbersAndPunctuation so whenever users try to add the negative symbol it will be correctly presented and handled.
+If you want your users to be able to input negative values just set textField's `keyboardType` to `.numbersAndPunctuation`, so whenever users tap the negative symbol it will be correctly presented and handled.
 
 ```Swift
 textField.keyboardType = .numbersAndPunctuation

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/marinofelipe/CurrencyText.svg?branch=master)](https://travis-ci.org/marinofelipe/CurrencyText)
 [![Coverage Status](https://coveralls.io/repos/github/marinofelipe/CurrencyText/badge.svg?branch=master)](https://coveralls.io/github/marinofelipe/CurrencyText?branch=master)
 <a href="https://swift.org"><img src="https://img.shields.io/badge/Swift-4.2-orange.svg?style=flat" alt="Swift" /></a>
-[![CocoaPods Compatible](https://img.shields.io/badge/pod-v2.0.1-blue.svg)](https://cocoapods.org/pods/CurrencyText)
+[![CocoaPods Compatible](https://img.shields.io/badge/pod-v2.0.2-blue.svg)](https://cocoapods.org/pods/CurrencyText)
 [![Platform](https://img.shields.io/cocoapods/p/CurrencyText.svg?style=flat)]()
 [![Twitter](https://img.shields.io/badge/twitter-@_marinofelipe-blue.svg?style=flat)](https://twitter.com/_marinofelipe)
 
@@ -30,6 +30,7 @@ If you need to present currency text or allow users to input currency data, Curr
   - [Advanced setup](#advancedsetup)
 - [The `CurrencyTextFieldDelegate`](#delegate)
   - [Setting your text field to format the inputs](#setting)
+  - [Allowing users to input `negative values`](#negative)
 - [All properties of `CurrencyFormatter`](#properties)
 - [Requirements](#requirements)
 - [Installation](#installation)
@@ -153,7 +154,19 @@ textFieldDelegate.clearsWhenValueIsZero = true
 textField.delegate = textFieldDelegate
 ```
 
-Just by setting a currency text field delegate object to your text field, with given formatter behaviour, the user inputs are going to be formatter as expected.
+Just by setting a currency text field delegate object to your text field, with given formatter behaviour, the user inputs are going to be formatted as expected.
+
+<a name="negative"/>
+
+### Allowing users to input `negative values`
+It's possible to allow users to input negative values. For it just set the keyboardType to .numbersAndPunctuation so whenever users try to add the negative symbol it will be correctly presented and handled.
+
+```Swift
+textField.keyboardType = .numbersAndPunctuation
+
+// users inputs "-3456"
+// -R$ 34.56
+```
 
 <a name="properties"/>
 
@@ -208,7 +221,7 @@ $ sudo gem install cocoapods
 
 To integrate CurrencyText into your Xcode project using CocoaPods, specify it in your `Podfile`:
 
-**Tested with `pod --version`: `2.0.1`**
+**Tested with `pod --version`: `2.0.2`**
 
 ```ruby
 # Podfile
@@ -240,7 +253,9 @@ _Carthage support is comming soon. If you want to help, please contribute :smile
 Contributions and feedbacks are always welcome. Please feel free to fork, follow, open issues and pull requests. The issues, milestones, and what we are currently working on can be seen in the main [Project](https://github.com/marinofelipe/CurrencyText/projects/1).
 
 ## Special Thanks
-Some readme details, "CurrencyLocale" enum and the init with handler callback were inspired by [@malcommac](https://github.com/malcommac) and his awesome work with SwiftRichString and SwfitDate.
+To [@malcommac](https://github.com/malcommac) for his awesome work with SwiftRichString and SwfitDate, that inspired some readme details, "CurrencyLocale" enum and the init with handler callback.
+Also to [myanalysis](https://github.com/myanalysis) for contributing so much by finding issues and giving nice suggestions.
+
 
 ## Copyright
 CurrencyText is released under the MIT license. [See LICENSE](https://github.com/marinofelipe/CurrencyText/blob/master/LICENSE) for details.

--- a/Sources/Formatter/CurrencyFormatter.swift
+++ b/Sources/Formatter/CurrencyFormatter.swift
@@ -277,10 +277,13 @@ extension CurrencyFormatter {
     /// - Parameter string: formatted string
     /// - Returns: updated formatted string
     public func updated(formattedString string: String) -> String? {
-        let isNegative: Bool = string.contains("-")
         var updatedString = string.numeralFormat()
-        updatedString = isNegative ? "-" + updatedString : updatedString
+        
+        let isNegative: Bool = string.contains(String.negativeSymbol)
+        updatedString = isNegative ? .negativeSymbol + updatedString : updatedString
+        
         updatedString.updateDecimalSeparator(decimalDigits: decimalDigits)
+        
         let value = getAdjustedForDefinedInterval(value: double(from: updatedString))
         return self.string(from: value)
     }

--- a/Sources/Formatter/CurrencyFormatter.swift
+++ b/Sources/Formatter/CurrencyFormatter.swift
@@ -277,7 +277,9 @@ extension CurrencyFormatter {
     /// - Parameter string: formatted string
     /// - Returns: updated formatted string
     public func updated(formattedString string: String) -> String? {
+        let isNegative: Bool = string.contains("-")
         var updatedString = string.numeralFormat()
+        updatedString = isNegative ? "-" + updatedString : updatedString
         updatedString.updateDecimalSeparator(decimalDigits: decimalDigits)
         let value = getAdjustedForDefinedInterval(value: double(from: updatedString))
         return self.string(from: value)

--- a/Sources/Formatter/String.swift
+++ b/Sources/Formatter/String.swift
@@ -47,3 +47,7 @@ extension String: CurrencyString {
         return replacingOccurrences(of:"[^0-9]", with: "", options: .regularExpression)
     }
 }
+
+extension String {
+    static let negativeSymbol = "-"
+}

--- a/Sources/TextField/CurrencyUITextFieldDelegate.swift
+++ b/Sources/TextField/CurrencyUITextFieldDelegate.swift
@@ -68,12 +68,14 @@ extension CurrencyUITextFieldDelegate {
     ///   - range: user input range
     ///   - string: user input string
     private func addNegativeSymbolIfNeeded(in textField: UITextField, at range: NSRange, replacementString string: String) {
-        if textField.keyboardType == .numbersAndPunctuation {
-            if string == "-" && textField.text?.isEmpty == true {
-                textField.text = "-"
-            } else if range.lowerBound == 0 && string == "-" {
-                textField.text = "-" + (textField.text ?? "")
-            }
+        guard textField.keyboardType == .numbersAndPunctuation else { return }
+        
+        if string == .negativeSymbol && textField.text?.isEmpty == true {
+            textField.text = .negativeSymbol
+        } else if range.lowerBound == 0 && string == .negativeSymbol &&
+            textField.text?.contains(String.negativeSymbol) == false {
+            
+            textField.text = .negativeSymbol + (textField.text ?? "")
         }
     }
     

--- a/Sources/TextField/CurrencyUITextFieldDelegate.swift
+++ b/Sources/TextField/CurrencyUITextFieldDelegate.swift
@@ -38,7 +38,10 @@ extension CurrencyUITextFieldDelegate: UITextFieldDelegate {
             updateSelectedTextRange(in: textField, previousOffsetFromEnd: previousSelectedTextRangeOffsetFromEnd)
             return false
         }
-        guard string.hasNumbers else { return false }
+        guard string.hasNumbers else {
+            addNegativeSymbolIfNeeded(in: textField, at: range, replacementString: string)
+            return false
+        }
         
         setFormattedText(in: textField, inputString: string, range: range)
         updateSelectedTextRange(in: textField, previousOffsetFromEnd: previousSelectedTextRangeOffsetFromEnd)
@@ -57,6 +60,28 @@ extension CurrencyUITextFieldDelegate: UITextFieldDelegate {
 
 extension CurrencyUITextFieldDelegate {
     
+    /// Verifies if user inputed a negative symbol at the first lowest
+    /// bound of the text field and add it.
+    ///
+    /// - Parameters:
+    ///   - textField: text field that user interacted with
+    ///   - range: user input range
+    ///   - string: user input string
+    private func addNegativeSymbolIfNeeded(in textField: UITextField, at range: NSRange, replacementString string: String) {
+        if textField.keyboardType == .numbersAndPunctuation {
+            if string == "-" && textField.text?.isEmpty == true {
+                textField.text = "-"
+            } else if range.lowerBound == 0 && string == "-" {
+                textField.text = "-" + (textField.text ?? "")
+            }
+        }
+    }
+    
+    /// Correctly delete characters when user taps remove key.
+    ///
+    /// - Parameters:
+    ///   - textField: text field that user interacted with
+    ///   - range: range to be removed
     private func handleDeletion(in textField: UITextField, at range: NSRange) {
         if var text = textField.text {
             if let textRange = Range(range, in: text) {
@@ -69,6 +94,11 @@ extension CurrencyUITextFieldDelegate {
         }
     }
     
+    /// Update selected text range after changing it's text.
+    ///
+    /// - Parameters:
+    ///   - textField: text field that user interacted with
+    ///   - previousOffsetFromEnd: offset from end before string has changed
     private func updateSelectedTextRange(in textField: UITextField, previousOffsetFromEnd: Int) {
         var offset = previousOffsetFromEnd
         if let text = textField.text, text.isEmpty {
@@ -77,6 +107,12 @@ extension CurrencyUITextFieldDelegate {
         textField.updateSelectedTextRange(offsetFromEnd: offset)
     }
     
+    /// Formats text field's text with new input string and changed range
+    ///
+    /// - Parameters:
+    ///   - textField: text field that user interacted with
+    ///   - inputString: typed string
+    ///   - range: range where the string should be added
     private func setFormattedText(in textField: UITextField, inputString: String, range: NSRange) {
         var updatedText = ""
         


### PR DESCRIPTION
### Why?
To allow users to input negative values

### Changes
- Improve some methods documenting
- Release 2.0.2 patch
- Handle adding negative symbol

### Tests 
Unit test negative symbol scenarios

### Issue - #38 