### PR TITLE
fix double from string

### DIFF
--- a/CurrencyText.podspec
+++ b/CurrencyText.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "CurrencyText"
-  s.version      = "2.0.2"
+  s.version      = "2.0.3"
   s.summary      = "Currency text formatter that fits your UITextField subclass."
 
   s.homepage     = "https://github.com/marinofelipe/CurrencyText"

--- a/Example/CurrencyText.xcodeproj/project.pbxproj
+++ b/Example/CurrencyText.xcodeproj/project.pbxproj
@@ -143,8 +143,8 @@
 				D54A412121D582C100281AD2 /* UITextFieldTests.swift */,
 				D54A412321D582CE00281AD2 /* NumberFormatterTests.swift */,
 				D54A412521D73FA400281AD2 /* UITextField.swift */,
-				D54170F0209023D8008995D7 /* Info.plist */,
 				D56D7C232211D4830032F684 /* CurrencyFormatterTests.swift */,
+				D54170F0209023D8008995D7 /* Info.plist */,
 			);
 			path = CurrencyTextDemoTests;
 			sourceTree = "<group>";

--- a/Example/CurrencyText.xcodeproj/project.pbxproj
+++ b/Example/CurrencyText.xcodeproj/project.pbxproj
@@ -270,7 +270,7 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-CurrencyTextDemo/Pods-CurrencyTextDemo-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-CurrencyTextDemo/Pods-CurrencyTextDemo-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/CurrencyText/CurrencyText.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -281,7 +281,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CurrencyTextDemo/Pods-CurrencyTextDemo-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-CurrencyTextDemo/Pods-CurrencyTextDemo-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		65905C8D491C77806121AF87 /* [CP] Check Pods Manifest.lock */ = {

--- a/Example/CurrencyTextDemoTests/CurrencyFormatterTests.swift
+++ b/Example/CurrencyTextDemoTests/CurrencyFormatterTests.swift
@@ -113,4 +113,26 @@ class CurrencyFormatterTests: XCTestCase {
         let doubleValue = formatter.double(from: "30000054")
         XCTAssertEqual(doubleValue, 30000054.00)
     }
+    
+    func testDoubleFromStringForDifferentFormatters() {
+        formatter.locale = CurrencyLocale.portugueseBrazil
+        formatter.currency = .euro
+        formatter.hasDecimals = true
+        
+        var doubleValue = formatter.double(from: "00.02")
+        XCTAssertEqual(doubleValue, 0.02)
+        
+        formatter.locale = CurrencyLocale.dutchBelgium
+        formatter.currency = .dollar
+        formatter.hasDecimals = false
+        
+        doubleValue = formatter.double(from: "00.02")
+        XCTAssertEqual(doubleValue, 0.02)
+        
+        formatter.locale = CurrencyLocale.zarma
+        formatter.hasDecimals = false
+        
+        doubleValue = formatter.double(from: "100.12")
+        XCTAssertEqual(doubleValue, 100.12)
+    }
 }

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - CurrencyText (1.0.2):
-    - CurrencyText/Formatter (= 1.0.2)
-  - CurrencyText/Formatter (1.0.2)
+  - CurrencyText (2.0.2):
+    - CurrencyText/Formatter (= 2.0.2)
+  - CurrencyText/Formatter (2.0.2)
 
 DEPENDENCIES:
   - CurrencyText (from `../`)
@@ -11,8 +11,8 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  CurrencyText: 827ce82befb77d6c5854e5d7a58f7f22b955fedb
+  CurrencyText: 33eb14503d052066479eb1a2e7b93bd9b6ea9fa9
 
 PODFILE CHECKSUM: 71330e76132253e9a3dde45c04bda457de089da1
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.6.1

--- a/Example/fastlane/Fastfile
+++ b/Example/fastlane/Fastfile
@@ -86,7 +86,7 @@ platform :ios do
   		
   		sh "git fetch --tags"
 	  	last_tag = last_git_tag
-	  	version_number = get_info_plist_value(path: './Pods/Target Support Files/UICurrencyTextField/Info.plist', key: 'CFBundleShortVersionString')
+	  	version_number = get_info_plist_value(path: './Pods/Target Support Files/CurrencyText/Info.plist', key: 'CFBundleShortVersionString')
 
 	  	if (Gem::Version.new(last_tag) >= Gem::Version.new(version_number))
 	    	if options[:force] 

--- a/Sources/Formatter/CurrencyFormatter.swift
+++ b/Sources/Formatter/CurrencyFormatter.swift
@@ -256,7 +256,7 @@ extension CurrencyFormatter {
     /// - Parameter string: string that describes the numerical value.
     /// - Returns: the value as a Double.
     public func double(from string: String) -> Double? {
-        return NumberFormatter().number(from: string)?.doubleValue
+        return Double(string)
     }
     
     /// Receives a currency formatted string and returns its


### PR DESCRIPTION
### Why?
To skip formatters aleatory behaviour and always correctly return a Double from a String when formatting text

### Changes
 - Update to cocoa pods 1.6.1
 - Fix double from string 
 - Release v. 2.0.3

### Tests 
- Test formatting double from string with different formatter setups