### PR TITLE
Improve initial selected text range

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,18 @@
-osx_image: xcode10.2
+osx_image: xcode11
 language: swift
-rvm:
-- 2.4.5
 
 cache:
 - bundler
 - cocoapods
 
 before_install:
-- cd Example && bundle install && cd ..
+- cd Example && bundle install
 
 install:
-- pod install --project-directory=Example
+- bundle exec pod install
 
 script:
-- pod lib lint
+- cd .. && pod lib lint
 
 after_success: 
 - cd Example && bundle exec fastlane test

--- a/Example/CurrencyTextDemo/Base.lproj/Main.storyboard
+++ b/Example/CurrencyTextDemo/Base.lproj/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -19,22 +17,23 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" adjustsFontSizeToFit="NO" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="qkW-Y1-m4o">
-                                <rect key="frame" x="50" y="120" width="275" height="50"/>
+                                <rect key="frame" x="50" y="100" width="275" height="50"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="4KN-T7-v2j"/>
                                 </constraints>
-                                <nil key="textColor"/>
+                                <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="25"/>
                                 <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="4 integers set up" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I3m-95-Uoa">
-                                <rect key="frame" x="94.5" y="80.5" width="186.5" height="31.5"/>
+                                <rect key="frame" x="94.5" y="60.5" width="186.5" height="31.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="26"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="qkW-Y1-m4o" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="50" id="1WU-oD-Qeb"/>
                             <constraint firstItem="qkW-Y1-m4o" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="Aao-me-7ob"/>
@@ -51,6 +50,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="138" y="133"/>
         </scene>
     </scenes>
 </document>

--- a/Example/CurrencyTextDemo/ViewController.swift
+++ b/Example/CurrencyTextDemo/ViewController.swift
@@ -26,9 +26,8 @@ class ViewController: UIViewController {
             $0.maxValue = 1000000
             $0.minValue = -1000000
             $0.currency = .euro
-            $0.locale = CurrencyLocale.frenchFrance
+            $0.locale = CurrencyLocale.german
             $0.hasDecimals = false
-            $0.currencySymbol = "euros"
         }
         
         textFieldDelegate = CurrencyUITextFieldDelegate(formatter: currencyFormatter)

--- a/Example/CurrencyTextDemoTests/UITextFieldTests.swift
+++ b/Example/CurrencyTextDemoTests/UITextFieldTests.swift
@@ -8,36 +8,136 @@
 
 import XCTest
 
-class UITextFieldTests: XCTestCase {
-    
+final class UITextFieldTests: XCTestCase {
+
+    // System under test.
     let textField = UITextField()
 
-    func testUpdatingSelectedTextRange() {
-        textField.text?.append("352450260")
-        
-        textField.updateSelectedTextRange(lastOffsetFromEnd: 0)
-        XCTAssertEqual(textField.selectedTextRange?.end, textField.position(from: textField.endOfDocument, offset: 0))
-        
-        textField.updateSelectedTextRange(lastOffsetFromEnd: -5)
-        XCTAssertEqual(textField.selectedTextRange?.end, textField.position(from: textField.endOfDocument, offset: -5))
+    // MARK: - selectedTextRangeOffsetFromEnd
+
+    func testOffsetFromEndWhenSelectedTextRangeIsAtTheEnd() {
+        setTextFieldWithNumericText()
+
+        // Set selected text range to the end
+        textField.selectedTextRange = textField.textRange(from: textField.endOfDocument,
+                                                          to: textField.endOfDocument)
+
+        // Then
+        XCTAssertEqual(textField.selectedTextRangeOffsetFromEnd, 0, "It has no offset from end")
     }
-    
-    func testGettingOffsetFromEnd() {
-        textField.text?.append("450")
-        
-        var position = textField.position(from: textField.endOfDocument, offset: 0)
-        textField.selectedTextRange = textField.textRange(from: position!, to: position!)
-        
-        XCTAssertEqual(textField.selectedTextRangeOffsetFromEnd, 0)
-        
-        textField.text?.append("35")
-        position = textField.position(from: textField.endOfDocument, offset: -4)
-        textField.selectedTextRange = textField.textRange(from: position!, to: position!)
-        XCTAssertEqual(textField.selectedTextRangeOffsetFromEnd, -4)
-        
-        textField.text?.removeLast()
-        position = textField.position(from: textField.endOfDocument, offset: -1)
-        textField.selectedTextRange = textField.textRange(from: position!, to: position!)
-        XCTAssertEqual(textField.selectedTextRangeOffsetFromEnd, -1)
+
+    func testOffsetFromEndWhenSelectedTextRangeIsNotAtTheEnd() throws {
+        setTextFieldWithNumericText()
+
+        // Set selected text range to a text position that is not at the end
+        let offset = -4
+        let textPosition = try XCTUnwrap(textField.position(from: textField.endOfDocument, offset: offset))
+        textField.selectedTextRange = textField.textRange(from: textPosition,
+                                                          to: textPosition)
+
+        // Then
+        XCTAssertEqual(textField.selectedTextRangeOffsetFromEnd, offset, "It has the correct offset from end")
+
+    }
+
+    // MARK: - Initial selected text range
+
+    func testSettingInitialSelectedTextRangeWithLastNumberAtTheNEnd() {
+        setTextFieldWithNumericText()
+
+        // Set initial selected text range
+        textField.setInitialSelectedTextRange()
+
+        // Then
+        XCTAssertEqual(textField.selectedTextRange,
+                       textField.textRange(from: textField.endOfDocument,
+                                           to: textField.endOfDocument),
+                       "It has the selected text range at the end")
+    }
+
+    func testSettingInitialSelectedTextRangeWithLastNumberNotAtTheNEnd() throws {
+        setTextFieldWithCurrencySymbolAtTheEnd()
+
+        // Set initial selected text range
+        textField.setInitialSelectedTextRange()
+
+        // Then
+        let lastNumberTextPosition = try XCTUnwrap(textField.position(from: textField.endOfDocument, offset: -2))
+        XCTAssertEqual(textField.selectedTextRange,
+                       textField.textRange(from: lastNumberTextPosition,
+                                           to: lastNumberTextPosition),
+                       "It has the correct selected text range")
+    }
+
+    // MARK: - Update selected text range
+
+    func testUpdatingSelectedTextRangeWithoutOffsetFromEnd() {
+        setTextFieldWithNumericText()
+
+        // Call update selected text range with no offset
+        textField.updateSelectedTextRange(lastOffsetFromEnd: 0)
+
+        // Then
+        XCTAssertEqual(textField.selectedTextRange,
+                       textField.textRange(from: textField.endOfDocument,
+                                           to: textField.endOfDocument),
+                       "It has the correct selected text range")
+    }
+
+    func testUpdatingSelectedTextRangeWithoutOffsetFromEndButLastNumberNotAtTheEnd() throws {
+        setTextFieldWithCurrencySymbolAtTheEnd()
+
+        // Call update selected text range with no offset
+        textField.updateSelectedTextRange(lastOffsetFromEnd: 0)
+
+        // Then
+        let lastNumberTextPosition = try XCTUnwrap(textField.position(from: textField.endOfDocument, offset: -2))
+        XCTAssertEqual(textField.selectedTextRange,
+                       textField.textRange(from: lastNumberTextPosition,
+                                           to: lastNumberTextPosition),
+                       "It has the correct selected text range")
+    }
+
+    func testUpdatingSelectedTextRangeWithOffsetFromEndAndBeforeLastNumber() throws {
+        setTextFieldWithCurrencySymbolAtTheEnd()
+
+        // Call update selected text range with offset before last number
+        let offset = -6
+        textField.updateSelectedTextRange(lastOffsetFromEnd: offset)
+
+        // Then
+        let textPositionForGivenOffset = try XCTUnwrap(textField.position(from: textField.endOfDocument, offset: offset))
+        XCTAssertEqual(textField.selectedTextRange,
+                       textField.textRange(from: textPositionForGivenOffset,
+                                           to: textPositionForGivenOffset),
+                       "It has the correct selected text range")
+    }
+
+    func testUpdatingSelectedTextRangeWithOffsetFromEndButAfterLastNumber() throws {
+        setTextFieldWithCurrencySymbolAtTheEnd()
+
+        // Call update selected text range with offset before last number
+        let offset = -1
+        textField.updateSelectedTextRange(lastOffsetFromEnd: offset)
+
+        // Then
+        let lastNumberTextPosition = try XCTUnwrap(textField.position(from: textField.endOfDocument, offset: -2))
+        XCTAssertEqual(textField.selectedTextRange,
+                       textField.textRange(from: lastNumberTextPosition,
+                                           to: lastNumberTextPosition),
+                       "It has the correct selected text range")
+    }
+}
+
+// MARK: - Helpers
+
+extension UITextFieldTests {
+
+    func setTextFieldWithNumericText() {
+        textField.text = "352450260"
+    }
+
+    func setTextFieldWithCurrencySymbolAtTheEnd() {
+        textField.text = "3.524,50 $"
     }
 }

--- a/Example/CurrencyTextDemoTests/UITextFieldTests.swift
+++ b/Example/CurrencyTextDemoTests/UITextFieldTests.swift
@@ -10,25 +10,15 @@ import XCTest
 
 class UITextFieldTests: XCTestCase {
     
-    var textField: UITextField!
-
-    override func setUp() {
-        super.setUp()
-        textField = UITextField()
-    }
-
-    override func tearDown() {
-        textField = nil
-        super.tearDown()
-    }
+    let textField = UITextField()
 
     func testUpdatingSelectedTextRange() {
         textField.text?.append("352450260")
         
-        textField.updateSelectedTextRange(offsetFromEnd: 0)
+        textField.updateSelectedTextRange(lastOffsetFromEnd: 0)
         XCTAssertEqual(textField.selectedTextRange?.end, textField.position(from: textField.endOfDocument, offset: 0))
         
-        textField.updateSelectedTextRange(offsetFromEnd: -5)
+        textField.updateSelectedTextRange(lastOffsetFromEnd: -5)
         XCTAssertEqual(textField.selectedTextRange?.end, textField.position(from: textField.endOfDocument, offset: -5))
     }
     

--- a/Sources/TextField/CurrencyUITextFieldDelegate.swift
+++ b/Sources/TextField/CurrencyUITextFieldDelegate.swift
@@ -26,7 +26,18 @@ public class CurrencyUITextFieldDelegate: NSObject {
     }
 }
 
+// MARK: - UITextFieldDelegate
+
 extension CurrencyUITextFieldDelegate: UITextFieldDelegate {
+
+    public func textFieldDidBeginEditing(_ textField: UITextField) {
+        // force selected text range to be at the end, even when it already has text
+        textField.selectedTextRange = textField.textRange(from: textField.endOfDocument, to: textField.endOfDocument)
+        let previousSelectedTextRangeOffsetFromEnd = textField.selectedTextRangeOffsetFromEnd
+
+        // update selected text range if needed
+        updateSelectedTextRange(in: textField, previousOffsetFromEnd: previousSelectedTextRangeOffsetFromEnd)
+    }
     
     @discardableResult
     public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
@@ -57,6 +68,8 @@ extension CurrencyUITextFieldDelegate: UITextFieldDelegate {
         return true
     }
 }
+
+// MARK: - Private
 
 extension CurrencyUITextFieldDelegate {
     

--- a/Sources/TextField/UITextField.swift
+++ b/Sources/TextField/UITextField.swift
@@ -8,14 +8,54 @@
 import UIKit
 
 public extension UITextField {
-    
-    func updateSelectedTextRange(offsetFromEnd: Int) {
+
+    // MARK: Public
+
+    var selectedTextRangeOffsetFromEnd: Int {
+        return offset(from: endOfDocument, to: selectedTextRange?.end ?? endOfDocument)
+    }
+
+    /// Sets the selected text range when the text field is starting to be edited.
+    /// _Should_ be called when text field start to be the first responder.
+    func setInitialSelectedTextRange() {
+        // update selected text range if needed
+        adjustSelectedTextRange(lastOffsetFromEnd: 0) // at the end when first selected
+    }
+
+    /// Interface to update the selected text range as expected.
+    /// - Parameter lastOffsetFromEnd: The last stored selected text range offset from end. Used to keep it concise with pre-formatting.
+    func updateSelectedTextRange(lastOffsetFromEnd: Int) {
+        adjustSelectedTextRange(lastOffsetFromEnd: lastOffsetFromEnd)
+    }
+
+    // MARK: Private
+
+    /// Adjust the selected text range to match the best position.
+    private func adjustSelectedTextRange(lastOffsetFromEnd: Int) {
+        /// If text is empty the offset is set to zero, the selected text range does need to be changed.
+        if let text = text, text.isEmpty {
+            return
+        }
+
+        var offsetFromEnd = lastOffsetFromEnd
+
+        /// Adjust offset if needed. When the last number character offset from end is less than the current offset,
+        /// or in other words, is more distant to the end of the string, the offset is readjusted to it,
+        /// so the selected text range is correctly set to the last index with a number.
+        if let lastNumberOffsetFromEnd = text?.lastNumberOffsetFromEnd,
+            case let shouldOffsetBeAdjusted = lastNumberOffsetFromEnd < offsetFromEnd,
+            shouldOffsetBeAdjusted {
+
+            offsetFromEnd = lastNumberOffsetFromEnd
+        }
+
+        updateSelectedTextRange(offsetFromEnd: offsetFromEnd)
+    }
+
+    /// Update the selected text range with given offset from end.
+    private func updateSelectedTextRange(offsetFromEnd: Int) {
         if let updatedCursorPosition = position(from: endOfDocument, offset: offsetFromEnd) {
             selectedTextRange = textRange(from: updatedCursorPosition, to: updatedCursorPosition)
         }
-    }
-    
-    var selectedTextRangeOffsetFromEnd: Int {
-        return offset(from: endOfDocument, to: selectedTextRange?.end ?? endOfDocument)
     }
 }


### PR DESCRIPTION
### Why?
To complement #48 , by adjusting the initial selected text range to match the position after the last number.

### Changes
- Update example
- Improve initial selected text range
- Move code to UITextField

### Tests 
- Add more tests for UITextField.

### Related to a suggestion that @nikolaveljic64 gave on #46 .