### PR TITLE
Added passthrough delegate and improved cursor handling

### DIFF
--- a/Example/Example/Base.lproj/Main.storyboard
+++ b/Example/Example/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -32,20 +32,38 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Value without formatting" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fMB-mB-boF">
+                                <rect key="frame" x="81.5" y="190" width="212" height="24"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Value with formatting" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2r1-l2-upc">
+                                <rect key="frame" x="95.5" y="158" width="184" height="24"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="qkW-Y1-m4o" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="50" id="1WU-oD-Qeb"/>
+                            <constraint firstItem="2r1-l2-upc" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="2WV-nU-pXz"/>
                             <constraint firstItem="qkW-Y1-m4o" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="Aao-me-7ob"/>
+                            <constraint firstItem="fMB-mB-boF" firstAttribute="top" secondItem="2r1-l2-upc" secondAttribute="bottom" constant="8" id="Nam-oV-YhV"/>
                             <constraint firstItem="I3m-95-Uoa" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="P3v-T0-m42"/>
                             <constraint firstItem="qkW-Y1-m4o" firstAttribute="top" secondItem="I3m-95-Uoa" secondAttribute="bottom" constant="8" id="RXx-9q-fH0"/>
                             <constraint firstItem="qkW-Y1-m4o" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="100" id="bZU-F7-lCz"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="qkW-Y1-m4o" secondAttribute="trailing" constant="50" id="dMd-Fw-yo0"/>
+                            <constraint firstItem="2r1-l2-upc" firstAttribute="top" secondItem="qkW-Y1-m4o" secondAttribute="bottom" constant="8" id="fiW-QJ-5y8"/>
+                            <constraint firstItem="fMB-mB-boF" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="gPb-yv-eHV"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <connections>
+                        <outlet property="formattedLabel" destination="2r1-l2-upc" id="DTj-47-7sS"/>
                         <outlet property="textField" destination="qkW-Y1-m4o" id="MyP-Cx-6AS"/>
+                        <outlet property="unformattedLabel" destination="fMB-mB-boF" id="sPW-AC-7GD"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -17,7 +17,9 @@ import CurrencyText
 class ViewController: UIViewController {
 
     @IBOutlet weak private var textField: UITextField!
-    
+    @IBOutlet weak private var formattedLabel: UILabel!
+    @IBOutlet weak private var unformattedLabel: UILabel!
+
     private var textFieldDelegate: CurrencyUITextFieldDelegate!
     
     override func viewDidLoad() {
@@ -28,15 +30,16 @@ class ViewController: UIViewController {
     
     private func setupTextFieldWithCurrencyDelegate() {
         let currencyFormatter = CurrencyFormatter {
-            $0.maxValue = 1000000
-            $0.minValue = -1000000
-            $0.currency = .euro
-            $0.locale = CurrencyLocale.german
+            $0.maxValue = 100000000
+            $0.minValue = 1
+            $0.currency = .dollar
+            $0.locale = CurrencyLocale.englishUnitedStates
             $0.hasDecimals = false
         }
         
         textFieldDelegate = CurrencyUITextFieldDelegate(formatter: currencyFormatter)
         textFieldDelegate.clearsWhenValueIsZero = true
+        textFieldDelegate.passthroughDelegate = self
         
         textField.delegate = textFieldDelegate
         textField.keyboardType = .numbersAndPunctuation
@@ -48,5 +51,12 @@ class ViewController: UIViewController {
     
     @objc func resignAnyFirstReponder() {
         self.view.endEditing(false)
+    }
+}
+
+extension ViewController: UITextFieldDelegate {
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        formattedLabel.text = textField.text
+        unformattedLabel.text = textFieldDelegate.formatter.unformatted(string: textField.text ?? "0")
     }
 }

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - CurrencyText (2.0.6):
-    - CurrencyText/CurrencyFormatter (= 2.0.6)
-    - CurrencyText/CurrencyUITextField (= 2.0.6)
-  - CurrencyText/CurrencyFormatter (2.0.6)
-  - CurrencyText/CurrencyUITextField (2.0.6):
+  - CurrencyText (2.1.0):
+    - CurrencyText/CurrencyFormatter (= 2.1.0)
+    - CurrencyText/CurrencyUITextField (= 2.1.0)
+  - CurrencyText/CurrencyFormatter (2.1.0)
+  - CurrencyText/CurrencyUITextField (2.1.0):
     - CurrencyText/CurrencyFormatter
 
 DEPENDENCIES:
@@ -14,8 +14,8 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  CurrencyText: 26154dfb459d64fc3a9a64e186f188dbed3448a0
+  CurrencyText: fca69b6515469de582e900acda3451a6cc8cb821
 
 PODFILE CHECKSUM: df4615e9ffd9b145be305d0646b76baa5210c056
 
-COCOAPODS: 1.8.0
+COCOAPODS: 1.8.4

--- a/Sources/Formatter/CurrencyFormatter.swift
+++ b/Sources/Formatter/CurrencyFormatter.swift
@@ -215,9 +215,9 @@ public class CurrencyFormatter: CurrencyFormatterProtocol {
         return numberFormatter.maximumIntegerDigits + numberFormatter.maximumFractionDigits
     }
     
-    /// Initial
+    /// The value zero formatted to serve as initial text.
     public var initialText: String {
-        return string(from: 0) ?? "0.0"
+        numberFormatter.string(from: 0) ?? "0.0"
     }
     
     //MARK: - INIT

--- a/Sources/Formatter/String.swift
+++ b/Sources/Formatter/String.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 Felipe Lefèvre Marino. All rights reserved.
 //
 
-import UIKit
+import Foundation
 
 public protocol CurrencyString {
     var representsZero: Bool { get }

--- a/Sources/UITextFieldDelegate/CurrencyUITextFieldDelegate.swift
+++ b/Sources/UITextFieldDelegate/CurrencyUITextFieldDelegate.swift
@@ -16,14 +16,14 @@ import CurrencyFormatter
 
 /// Custom text field delegate
 public class CurrencyUITextFieldDelegate: NSObject {
-    
+
     public var formatter: CurrencyFormatterProtocol!
-    
+
     /// Text field clears its text when value value is equal to zero
     public var clearsWhenValueIsZero: Bool = false
-    
+
     weak public var passthroughDelegate: UITextFieldDelegate?
-    
+
     override public init() {
         super.init()
         self.formatter = CurrencyFormatter()
@@ -78,19 +78,19 @@ extension CurrencyUITextFieldDelegate: UITextFieldDelegate {
         }
         
         guard !string.isEmpty else {
-            handleCursor(textField: textField, changingCharactersIn: range) {
+            handleCursor(on: textField, changingCharactersIn: range) {
                 handleDeletion(in: textField, at: range)
             }
             return false
         }
         guard string.hasNumbers else {
-            handleCursor(textField: textField, changingCharactersIn: range) {
+            handleCursor(on: textField, changingCharactersIn: range) {
                 addNegativeSymbolIfNeeded(in: textField, at: range, replacementString: string)
             }
             return false
         }
         
-        handleCursor(textField: textField, changingCharactersIn: range) {
+        handleCursor(on: textField, changingCharactersIn: range) {
             setFormattedText(in: textField, inputString: string, range: range)
         }
         
@@ -111,7 +111,7 @@ extension CurrencyUITextFieldDelegate {
     ///   - textFieldUpdate: closure that updates text field text
     private func handleCursor(on textField: UITextField, changingCharactersIn range: NSRange, after textFieldUpdate: () -> Void) {
         let preFormatLength = textField.text?.count ?? 0
-        fieldAlterationAction()
+        textFieldUpdate()
         let postFormatLength = textField.text?.count ?? 0
         let lengthChange = postFormatLength - preFormatLength
         let cursorPosition = range.location + range.length + lengthChange

--- a/Sources/UITextFieldDelegate/CurrencyUITextFieldDelegate.swift
+++ b/Sources/UITextFieldDelegate/CurrencyUITextFieldDelegate.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 Felipe Lefèvre Marino. All rights reserved.
 //
 
-#if !os(macOS)
 import UIKit
 
 #if canImport(CurrencyFormatter)
@@ -197,4 +196,3 @@ extension CurrencyUITextFieldDelegate {
         textField.text = formatter.updated(formattedString: updatedText)
     }
 }
-#endif

--- a/Sources/UITextFieldDelegate/CurrencyUITextFieldDelegate.swift
+++ b/Sources/UITextFieldDelegate/CurrencyUITextFieldDelegate.swift
@@ -6,7 +6,9 @@
 //  Copyright © 2018 Felipe Lefèvre Marino. All rights reserved.
 //
 
+#if !os(macOS)
 import UIKit
+
 #if canImport(CurrencyFormatter)
 import CurrencyFormatter
 #endif
@@ -184,3 +186,4 @@ extension CurrencyUITextFieldDelegate {
         textField.text = formatter.updated(formattedString: updatedText)
     }
 }
+#endif

--- a/Sources/UITextFieldDelegate/CurrencyUITextFieldDelegate.swift
+++ b/Sources/UITextFieldDelegate/CurrencyUITextFieldDelegate.swift
@@ -168,7 +168,7 @@ extension CurrencyUITextFieldDelegate {
         
         if let text = textField.text {
             if text.isEmpty {
-                updatedText = formatter.string(from: Double(inputString)) ?? "0.0"
+                updatedText = formatter.initialText + inputString
             } else if let range = Range(range, in: text) {
                 updatedText = text.replacingCharacters(in: range, with: inputString)
             } else {

--- a/Sources/UITextFieldDelegate/CurrencyUITextFieldDelegate.swift
+++ b/Sources/UITextFieldDelegate/CurrencyUITextFieldDelegate.swift
@@ -100,7 +100,7 @@ extension CurrencyUITextFieldDelegate: UITextFieldDelegate {
 
 extension CurrencyUITextFieldDelegate {
     
-    private func handleCursor(textField: UITextField, changingCharactersIn range: NSRange, _ fieldAlterationAction: () -> Void ) {
+    private func handleCursor(on textField: UITextField, changingCharactersIn range: NSRange, after textFieldUpdate: () -> Void) {
         let preFormatLen = textField.text?.count ?? 0
         fieldAlterationAction()
         let postFormatLen = textField.text?.count ?? 0
@@ -181,4 +181,3 @@ extension CurrencyUITextFieldDelegate {
         textField.text = formatter.updated(formattedString: updatedText)
     }
 }
-

--- a/Sources/UITextFieldDelegate/CurrencyUITextFieldDelegate.swift
+++ b/Sources/UITextFieldDelegate/CurrencyUITextFieldDelegate.swift
@@ -13,16 +13,25 @@ import UIKit
 import CurrencyFormatter
 #endif
 
-
-/// Custom text field delegate
+/// Custom text field delegate, that formats user inputs based on a given currency formatter.
 public class CurrencyUITextFieldDelegate: NSObject {
 
     public var formatter: CurrencyFormatterProtocol!
 
-    /// Text field clears its text when value value is equal to zero
+    /// Text field clears its text when value value is equal to zero.
     public var clearsWhenValueIsZero: Bool = false
 
-    weak public var passthroughDelegate: UITextFieldDelegate?
+    /// A delegate object to receive and potentially handle `UITextFieldDelegate events` that are sent to `CurrencyUITextFieldDelegate`.
+    /// _Note_: Make sure the implementation of this object does not wrongly interfere with currency formatting.
+    /// By returning `false` on`textField(textField:shouldChangeCharactersIn:replacementString:)` no currency formatting is done.
+    public var passthroughDelegate: UITextFieldDelegate? {
+        get { return _passthroughDelegate }
+        set {
+            guard newValue !== self else { return }
+            _passthroughDelegate = newValue
+        }
+    }
+    weak private var _passthroughDelegate: UITextFieldDelegate?
 
     override public init() {
         super.init()
@@ -72,8 +81,10 @@ extension CurrencyUITextFieldDelegate: UITextFieldDelegate {
     
     @discardableResult
     public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        
-        if !(passthroughDelegate?.textField?(textField, shouldChangeCharactersIn: range, replacementString: string) ?? true) {
+        let shouldChangeCharactersInRange = passthroughDelegate?.textField?(textField,
+                                                                            shouldChangeCharactersIn: range,
+                                                                            replacementString: string) ?? true
+        guard shouldChangeCharactersInRange else {
             return false
         }
         

--- a/Sources/UITextFieldDelegate/CurrencyUITextFieldDelegate.swift
+++ b/Sources/UITextFieldDelegate/CurrencyUITextFieldDelegate.swift
@@ -100,13 +100,20 @@ extension CurrencyUITextFieldDelegate: UITextFieldDelegate {
 
 extension CurrencyUITextFieldDelegate {
     
+    /// Capture current cursor position, allow the field to be altered, 
+    /// then restore the cursor position to the correct location.
+    ///
+    /// - Parameters:
+    ///   - textField: text field that user interacted with
+    ///   - range: range of characters changing
+    ///   - textFieldUpdate: closure that updates text field text
     private func handleCursor(on textField: UITextField, changingCharactersIn range: NSRange, after textFieldUpdate: () -> Void) {
-        let preFormatLen = textField.text?.count ?? 0
+        let preFormatLength = textField.text?.count ?? 0
         fieldAlterationAction()
-        let postFormatLen = textField.text?.count ?? 0
-        let lengthChange = postFormatLen - preFormatLen
-        let cursorPos = range.location + range.length + lengthChange
-        if let newPosition = textField.position(from: textField.beginningOfDocument, offset: cursorPos) {
+        let postFormatLength = textField.text?.count ?? 0
+        let lengthChange = postFormatLength - preFormatLength
+        let cursorPosition = range.location + range.length + lengthChange
+        if let newPosition = textField.position(from: textField.beginningOfDocument, offset: cursorPosition) {
             textField.selectedTextRange = textField.textRange(from: newPosition, to: newPosition)
         }
     }
@@ -143,10 +150,10 @@ extension CurrencyUITextFieldDelegate {
                 text.removeLast()
             }
             
-            if text.count > 0 {
-                textField.text = formatter.updated(formattedString: text)
-            } else {
+            if text.isEmpty {
                 textField.text = text
+            } else {
+                textField.text = formatter.updated(formattedString: text)
             }
         }
     }
@@ -162,11 +169,7 @@ extension CurrencyUITextFieldDelegate {
         
         if let text = textField.text {
             if text.isEmpty {
-                if text.count > 0 {
-                    updatedText = formatter.initialText + inputString
-                } else {
-                    updatedText = formatter.string(from: Double(inputString)) ?? "0.0"
-                }
+                updatedText = formatter.string(from: Double(inputString)) ?? "0.0"
             } else if let range = Range(range, in: text) {
                 updatedText = text.replacingCharacters(in: range, with: inputString)
             } else {

--- a/Sources/UITextFieldDelegate/UITextField.swift
+++ b/Sources/UITextFieldDelegate/UITextField.swift
@@ -5,7 +5,6 @@
 //  Created by Felipe Lefèvre Marino on 12/26/18.
 //
 
-#if !os(macOS)
 import UIKit
 
 public extension UITextField {
@@ -60,4 +59,3 @@ public extension UITextField {
         }
     }
 }
-#endif

--- a/Sources/UITextFieldDelegate/UITextField.swift
+++ b/Sources/UITextFieldDelegate/UITextField.swift
@@ -5,6 +5,7 @@
 //  Created by Felipe Lefèvre Marino on 12/26/18.
 //
 
+#if !os(macOS)
 import UIKit
 
 public extension UITextField {
@@ -59,3 +60,4 @@ public extension UITextField {
         }
     }
 }
+#endif


### PR DESCRIPTION
### Why?
I discovered that setting a minimum dollar amount of 1 caused an extraneous 1 to appended to the user entered value on the first key press.  This was caused by formatting, and enforcement of the minimum value, being applied to an empty field.

I found that cursor handling was not working well.  The cursor was leaping forward and backward 2 positions while entering and editing values.

### Changes
Do not apply formatting to empty text from the text field.  Only apply to the result of appending the newly entered character.

To fix the cursor position I calculate the difference between the previous text and the newly formatted text and move the cursor to its correct new position by wrapping all text modifying actions in a cursor handler.

### Tests 
To create the issue start in the Example ViewController and change the formatter setup:
            $0.minValue = 1
            $0.currency = .dollar
            $0.locale = CurrencyLocale.englishUnitedStates

For the cursor testing I set formatter maxValue = 100000000, then I entered 12345678 in the example field.  I then moved the cursor around with both the mouse and the arrow keys and used the delete key followed by a new number.

We are currently using this new code in an enterprise app and it works great.

### [Issue]() (optional) add link to the issue here
