### PR TITLE
Fix CI to fail when tests do not pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,4 @@ install:
 
 script:
 - cd .. && pod lib lint
-
-after_success: 
 - cd Example && bundle exec fastlane test


### PR DESCRIPTION
### Why?
Fix #60 .

### Changes
- Update .travis.yml to run test on script step instead of after_success.