### PR TITLE
Update example with 8 fields

### DIFF
--- a/CurrencyText.xcodeproj/project.pbxproj
+++ b/CurrencyText.xcodeproj/project.pbxproj
@@ -1,942 +1,759 @@
 // !$*UTF8*$!
 {
-   archiveVersion = "1";
-   objectVersion = "46";
-   objects = {
-      "CurrencyText::CurrencyFormatter" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_41";
-         buildPhases = (
-            "OBJ_44",
-            "OBJ_50"
-         );
-         dependencies = (
-         );
-         name = "CurrencyFormatter";
-         productName = "CurrencyFormatter";
-         productReference = "CurrencyText::CurrencyFormatter::Product";
-         productType = "com.apple.product-type.framework";
-      };
-      "CurrencyText::CurrencyFormatter::Product" = {
-         isa = "PBXFileReference";
-         path = "CurrencyFormatter.framework";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "CurrencyText::CurrencyText::ProductTarget" = {
-         isa = "PBXAggregateTarget";
-         buildConfigurationList = "OBJ_52";
-         buildPhases = (
-         );
-         dependencies = (
-            "OBJ_55",
-            "OBJ_56"
-         );
-         name = "CurrencyText";
-         productName = "CurrencyText";
-      };
-      "CurrencyText::CurrencyTextPackageTests::ProductTarget" = {
-         isa = "PBXAggregateTarget";
-         buildConfigurationList = "OBJ_65";
-         buildPhases = (
-         );
-         dependencies = (
-            "OBJ_68"
-         );
-         name = "CurrencyTextPackageTests";
-         productName = "CurrencyTextPackageTests";
-      };
-      "CurrencyText::CurrencyUITextFieldDelegate" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_70";
-         buildPhases = (
-            "OBJ_73",
-            "OBJ_76"
-         );
-         dependencies = (
-            "OBJ_78"
-         );
-         name = "CurrencyUITextFieldDelegate";
-         productName = "CurrencyUITextFieldDelegate";
-         productReference = "CurrencyText::CurrencyUITextFieldDelegate::Product";
-         productType = "com.apple.product-type.framework";
-      };
-      "CurrencyText::CurrencyUITextFieldDelegate::Product" = {
-         isa = "PBXFileReference";
-         path = "CurrencyUITextFieldDelegate.framework";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "CurrencyText::SwiftPMPackageDescription" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_59";
-         buildPhases = (
-            "OBJ_62"
-         );
-         dependencies = (
-         );
-         name = "CurrencyTextPackageDescription";
-         productName = "CurrencyTextPackageDescription";
-         productType = "com.apple.product-type.framework";
-      };
-      "CurrencyText::Tests" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_79";
-         buildPhases = (
-            "OBJ_82",
-            "OBJ_89"
-         );
-         dependencies = (
-            "OBJ_92",
-            "OBJ_93"
-         );
-         name = "Tests";
-         productName = "Tests";
-         productReference = "CurrencyText::Tests::Product";
-         productType = "com.apple.product-type.bundle.unit-test";
-      };
-      "CurrencyText::Tests::Product" = {
-         isa = "PBXFileReference";
-         path = "Tests.xctest";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "OBJ_1" = {
-         isa = "PBXProject";
-         attributes = {
-            LastSwiftMigration = "9999";
-            LastUpgradeCheck = "9999";
-         };
-         buildConfigurationList = "OBJ_2";
-         compatibilityVersion = "Xcode 3.2";
-         developmentRegion = "en";
-         hasScannedForEncodings = "0";
-         knownRegions = (
-            "en"
-         );
-         mainGroup = "OBJ_5";
-         productRefGroup = "OBJ_27";
-         projectDirPath = ".";
-         targets = (
-            "CurrencyText::CurrencyFormatter",
-            "CurrencyText::CurrencyText::ProductTarget",
-            "CurrencyText::SwiftPMPackageDescription",
-            "CurrencyText::CurrencyTextPackageTests::ProductTarget",
-            "CurrencyText::CurrencyUITextFieldDelegate",
-            "CurrencyText::Tests"
-         );
-      };
-      "OBJ_10" = {
-         isa = "PBXFileReference";
-         path = "CurrencyFormatter.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_11" = {
-         isa = "PBXFileReference";
-         path = "CurrencyLocale.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_12" = {
-         isa = "PBXFileReference";
-         path = "NumberFormatter.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_13" = {
-         isa = "PBXFileReference";
-         path = "String.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_14" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_15",
-            "OBJ_16"
-         );
-         name = "CurrencyUITextFieldDelegate";
-         path = "Sources/UITextFieldDelegate";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_15" = {
-         isa = "PBXFileReference";
-         path = "CurrencyUITextFieldDelegate.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_16" = {
-         isa = "PBXFileReference";
-         path = "UITextField.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_17" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_18"
-         );
-         name = "Tests";
-         path = "";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_18" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_19",
-            "OBJ_23"
-         );
-         name = "Tests";
-         path = "Tests";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_19" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_20",
-            "OBJ_21",
-            "OBJ_22"
-         );
-         name = "CurrencyFormatter";
-         path = "CurrencyFormatter";
-         sourceTree = "<group>";
-      };
-      "OBJ_2" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_3",
-            "OBJ_4"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_20" = {
-         isa = "PBXFileReference";
-         path = "CurrencyFormatterTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_21" = {
-         isa = "PBXFileReference";
-         path = "NumberFormatterTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_22" = {
-         isa = "PBXFileReference";
-         path = "StringTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_23" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_24",
-            "OBJ_25",
-            "OBJ_26"
-         );
-         name = "CurrencyText";
-         path = "CurrencyText";
-         sourceTree = "<group>";
-      };
-      "OBJ_24" = {
-         isa = "PBXFileReference";
-         path = "CurrencyTextFieldDelegateTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_25" = {
-         isa = "PBXFileReference";
-         path = "UITextField.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_26" = {
-         isa = "PBXFileReference";
-         path = "UITextFieldTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_27" = {
-         isa = "PBXGroup";
-         children = (
-            "CurrencyText::CurrencyFormatter::Product",
-            "CurrencyText::CurrencyUITextFieldDelegate::Product",
-            "CurrencyText::Tests::Product"
-         );
-         name = "Products";
-         path = "";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "OBJ_3" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_OBJC_ARC = "YES";
-            COMBINE_HIDPI_IMAGES = "YES";
-            COPY_PHASE_STRIP = "NO";
-            DEBUG_INFORMATION_FORMAT = "dwarf";
-            DYLIB_INSTALL_NAME_BASE = "@rpath";
-            ENABLE_NS_ASSERTIONS = "YES";
-            GCC_OPTIMIZATION_LEVEL = "0";
-            GCC_PREPROCESSOR_DEFINITIONS = (
-               "$(inherited)",
-               "SWIFT_PACKAGE=1",
-               "DEBUG=1"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            ONLY_ACTIVE_ARCH = "YES";
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-               "-DXcode"
-            );
-            PRODUCT_NAME = "$(TARGET_NAME)";
-            SDKROOT = "macosx";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator"
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)",
-               "SWIFT_PACKAGE",
-               "DEBUG"
-            );
-            SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-            USE_HEADERMAP = "NO";
-         };
-         name = "Debug";
-      };
-      "OBJ_31" = {
-         isa = "PBXFileReference";
-         path = "images";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_32" = {
-         isa = "PBXFileReference";
-         path = "Example";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_33" = {
-         isa = "PBXFileReference";
-         path = "CurrencyText.xcworkspace";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_34" = {
-         isa = "PBXFileReference";
-         path = "UICurrencyTextField.podspec";
-         sourceTree = "<group>";
-      };
-      "OBJ_35" = {
-         isa = "PBXFileReference";
-         path = "LICENSE";
-         sourceTree = "<group>";
-      };
-      "OBJ_36" = {
-         isa = "PBXFileReference";
-         path = "PULL_REQUEST_TEMPLATE.md";
-         sourceTree = "<group>";
-      };
-      "OBJ_37" = {
-         isa = "PBXFileReference";
-         path = "README.md";
-         sourceTree = "<group>";
-      };
-      "OBJ_38" = {
-         isa = "PBXFileReference";
-         path = "ISSUE_TEMPLATE.md";
-         sourceTree = "<group>";
-      };
-      "OBJ_39" = {
-         isa = "PBXFileReference";
-         path = "CurrencyText.podspec";
-         sourceTree = "<group>";
-      };
-      "OBJ_4" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_OBJC_ARC = "YES";
-            COMBINE_HIDPI_IMAGES = "YES";
-            COPY_PHASE_STRIP = "YES";
-            DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-            DYLIB_INSTALL_NAME_BASE = "@rpath";
-            GCC_OPTIMIZATION_LEVEL = "s";
-            GCC_PREPROCESSOR_DEFINITIONS = (
-               "$(inherited)",
-               "SWIFT_PACKAGE=1"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-               "-DXcode"
-            );
-            PRODUCT_NAME = "$(TARGET_NAME)";
-            SDKROOT = "macosx";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator"
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)",
-               "SWIFT_PACKAGE"
-            );
-            SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-            USE_HEADERMAP = "NO";
-         };
-         name = "Release";
-      };
-      "OBJ_41" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_42",
-            "OBJ_43"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_42" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "CurrencyText.xcodeproj/CurrencyFormatter_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "CurrencyFormatter";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "5.0";
-            TARGET_NAME = "CurrencyFormatter";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_43" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "CurrencyText.xcodeproj/CurrencyFormatter_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "CurrencyFormatter";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "5.0";
-            TARGET_NAME = "CurrencyFormatter";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Release";
-      };
-      "OBJ_44" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_45",
-            "OBJ_46",
-            "OBJ_47",
-            "OBJ_48",
-            "OBJ_49"
-         );
-      };
-      "OBJ_45" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_9";
-      };
-      "OBJ_46" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_10";
-      };
-      "OBJ_47" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_11";
-      };
-      "OBJ_48" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_12";
-      };
-      "OBJ_49" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_13";
-      };
-      "OBJ_5" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_6",
-            "OBJ_7",
-            "OBJ_17",
-            "OBJ_27",
-            "OBJ_31",
-            "OBJ_32",
-            "OBJ_33",
-            "OBJ_34",
-            "OBJ_35",
-            "OBJ_36",
-            "OBJ_37",
-            "OBJ_38",
-            "OBJ_39"
-         );
-         path = "";
-         sourceTree = "<group>";
-      };
-      "OBJ_50" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-         );
-      };
-      "OBJ_52" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_53",
-            "OBJ_54"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_53" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-         };
-         name = "Debug";
-      };
-      "OBJ_54" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-         };
-         name = "Release";
-      };
-      "OBJ_55" = {
-         isa = "PBXTargetDependency";
-         target = "CurrencyText::CurrencyFormatter";
-      };
-      "OBJ_56" = {
-         isa = "PBXTargetDependency";
-         target = "CurrencyText::CurrencyUITextFieldDelegate";
-      };
-      "OBJ_59" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_60",
-            "OBJ_61"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_6" = {
-         isa = "PBXFileReference";
-         explicitFileType = "sourcecode.swift";
-         path = "Package.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_60" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "5",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
-               "-package-description-version",
-               "5"
-            );
-            SWIFT_VERSION = "5.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_61" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "5",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
-               "-package-description-version",
-               "5"
-            );
-            SWIFT_VERSION = "5.0";
-         };
-         name = "Release";
-      };
-      "OBJ_62" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_63"
-         );
-      };
-      "OBJ_63" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_6";
-      };
-      "OBJ_65" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_66",
-            "OBJ_67"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_66" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-         };
-         name = "Debug";
-      };
-      "OBJ_67" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-         };
-         name = "Release";
-      };
-      "OBJ_68" = {
-         isa = "PBXTargetDependency";
-         target = "CurrencyText::Tests";
-      };
-      "OBJ_7" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_8",
-            "OBJ_14"
-         );
-         name = "Sources";
-         path = "";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_70" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_71",
-            "OBJ_72"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_71" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "CurrencyText.xcodeproj/CurrencyUITextFieldDelegate_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "CurrencyUITextFieldDelegate";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "5.0";
-            TARGET_NAME = "CurrencyUITextFieldDelegate";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_72" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "CurrencyText.xcodeproj/CurrencyUITextFieldDelegate_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "CurrencyUITextFieldDelegate";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "5.0";
-            TARGET_NAME = "CurrencyUITextFieldDelegate";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Release";
-      };
-      "OBJ_73" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_74",
-            "OBJ_75"
-         );
-      };
-      "OBJ_74" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_15";
-      };
-      "OBJ_75" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_16";
-      };
-      "OBJ_76" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-            "OBJ_77"
-         );
-      };
-      "OBJ_77" = {
-         isa = "PBXBuildFile";
-         fileRef = "CurrencyText::CurrencyFormatter::Product";
-      };
-      "OBJ_78" = {
-         isa = "PBXTargetDependency";
-         target = "CurrencyText::CurrencyFormatter";
-      };
-      "OBJ_79" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_80",
-            "OBJ_81"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_8" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_9",
-            "OBJ_10",
-            "OBJ_11",
-            "OBJ_12",
-            "OBJ_13"
-         );
-         name = "CurrencyFormatter";
-         path = "Sources/Formatter";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_80" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_MODULES = "YES";
-            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "CurrencyText.xcodeproj/Tests_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "@loader_path/../Frameworks",
-               "@loader_path/Frameworks"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "5.0";
-            TARGET_NAME = "Tests";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_81" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_MODULES = "YES";
-            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "CurrencyText.xcodeproj/Tests_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "@loader_path/../Frameworks",
-               "@loader_path/Frameworks"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "5.0";
-            TARGET_NAME = "Tests";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Release";
-      };
-      "OBJ_82" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_83",
-            "OBJ_84",
-            "OBJ_85",
-            "OBJ_86",
-            "OBJ_87",
-            "OBJ_88"
-         );
-      };
-      "OBJ_83" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_20";
-      };
-      "OBJ_84" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_21";
-      };
-      "OBJ_85" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_22";
-      };
-      "OBJ_86" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_24";
-      };
-      "OBJ_87" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_25";
-      };
-      "OBJ_88" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_26";
-      };
-      "OBJ_89" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-            "OBJ_90",
-            "OBJ_91"
-         );
-      };
-      "OBJ_9" = {
-         isa = "PBXFileReference";
-         path = "Currency.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_90" = {
-         isa = "PBXBuildFile";
-         fileRef = "CurrencyText::CurrencyUITextFieldDelegate::Product";
-      };
-      "OBJ_91" = {
-         isa = "PBXBuildFile";
-         fileRef = "CurrencyText::CurrencyFormatter::Product";
-      };
-      "OBJ_92" = {
-         isa = "PBXTargetDependency";
-         target = "CurrencyText::CurrencyUITextFieldDelegate";
-      };
-      "OBJ_93" = {
-         isa = "PBXTargetDependency";
-         target = "CurrencyText::CurrencyFormatter";
-      };
-   };
-   rootObject = "OBJ_1";
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXAggregateTarget section */
+		"CurrencyText::CurrencyText::ProductTarget" /* CurrencyText */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = OBJ_52 /* Build configuration list for PBXAggregateTarget "CurrencyText" */;
+			buildPhases = (
+			);
+			dependencies = (
+				OBJ_55 /* PBXTargetDependency */,
+				OBJ_56 /* PBXTargetDependency */,
+			);
+			name = CurrencyText;
+			productName = CurrencyText;
+		};
+		"CurrencyText::CurrencyTextPackageTests::ProductTarget" /* CurrencyTextPackageTests */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = OBJ_65 /* Build configuration list for PBXAggregateTarget "CurrencyTextPackageTests" */;
+			buildPhases = (
+			);
+			dependencies = (
+				OBJ_68 /* PBXTargetDependency */,
+			);
+			name = CurrencyTextPackageTests;
+			productName = CurrencyTextPackageTests;
+		};
+/* End PBXAggregateTarget section */
+
+/* Begin PBXBuildFile section */
+		OBJ_45 /* Currency.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* Currency.swift */; };
+		OBJ_46 /* CurrencyFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* CurrencyFormatter.swift */; };
+		OBJ_47 /* CurrencyLocale.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* CurrencyLocale.swift */; };
+		OBJ_48 /* NumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* NumberFormatter.swift */; };
+		OBJ_49 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* String.swift */; };
+		OBJ_63 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
+		OBJ_74 /* CurrencyUITextFieldDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* CurrencyUITextFieldDelegate.swift */; };
+		OBJ_75 /* UITextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_16 /* UITextField.swift */; };
+		OBJ_77 /* CurrencyFormatter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "CurrencyText::CurrencyFormatter::Product" /* CurrencyFormatter.framework */; };
+		OBJ_83 /* CurrencyFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* CurrencyFormatterTests.swift */; };
+		OBJ_84 /* NumberFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_21 /* NumberFormatterTests.swift */; };
+		OBJ_85 /* StringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_22 /* StringTests.swift */; };
+		OBJ_86 /* CurrencyTextFieldDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_24 /* CurrencyTextFieldDelegateTests.swift */; };
+		OBJ_87 /* UITextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_25 /* UITextField.swift */; };
+		OBJ_88 /* UITextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_26 /* UITextFieldTests.swift */; };
+		OBJ_90 /* CurrencyUITextFieldDelegate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "CurrencyText::CurrencyUITextFieldDelegate::Product" /* CurrencyUITextFieldDelegate.framework */; };
+		OBJ_91 /* CurrencyFormatter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "CurrencyText::CurrencyFormatter::Product" /* CurrencyFormatter.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		C167D3E623DBB682000DC9F3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "CurrencyText::CurrencyFormatter";
+			remoteInfo = CurrencyFormatter;
+		};
+		C167D3E723DBB682000DC9F3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "CurrencyText::CurrencyUITextFieldDelegate";
+			remoteInfo = CurrencyUITextFieldDelegate;
+		};
+		C167D3E823DBB682000DC9F3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "CurrencyText::CurrencyFormatter";
+			remoteInfo = CurrencyFormatter;
+		};
+		C167D3E923DBB683000DC9F3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "CurrencyText::Tests";
+			remoteInfo = Tests;
+		};
+		C167D3EA23DBB6A8000DC9F3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "CurrencyText::CurrencyFormatter";
+			remoteInfo = CurrencyFormatter;
+		};
+		C167D3EB23DBB6A8000DC9F3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "CurrencyText::CurrencyUITextFieldDelegate";
+			remoteInfo = CurrencyUITextFieldDelegate;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		"CurrencyText::CurrencyFormatter::Product" /* CurrencyFormatter.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CurrencyFormatter.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"CurrencyText::CurrencyUITextFieldDelegate::Product" /* CurrencyUITextFieldDelegate.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CurrencyUITextFieldDelegate.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"CurrencyText::Tests::Product" /* Tests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		OBJ_10 /* CurrencyFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyFormatter.swift; sourceTree = "<group>"; };
+		OBJ_11 /* CurrencyLocale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyLocale.swift; sourceTree = "<group>"; };
+		OBJ_12 /* NumberFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberFormatter.swift; sourceTree = "<group>"; };
+		OBJ_13 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
+		OBJ_15 /* CurrencyUITextFieldDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyUITextFieldDelegate.swift; sourceTree = "<group>"; };
+		OBJ_16 /* UITextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITextField.swift; sourceTree = "<group>"; };
+		OBJ_20 /* CurrencyFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyFormatterTests.swift; sourceTree = "<group>"; };
+		OBJ_21 /* NumberFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberFormatterTests.swift; sourceTree = "<group>"; };
+		OBJ_22 /* StringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringTests.swift; sourceTree = "<group>"; };
+		OBJ_24 /* CurrencyTextFieldDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyTextFieldDelegateTests.swift; sourceTree = "<group>"; };
+		OBJ_25 /* UITextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITextField.swift; sourceTree = "<group>"; };
+		OBJ_26 /* UITextFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITextFieldTests.swift; sourceTree = "<group>"; };
+		OBJ_31 /* images */ = {isa = PBXFileReference; lastKnownFileType = folder; path = images; sourceTree = SOURCE_ROOT; };
+		OBJ_32 /* Example */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Example; sourceTree = SOURCE_ROOT; };
+		OBJ_33 /* CurrencyText.xcworkspace */ = {isa = PBXFileReference; lastKnownFileType = wrapper.workspace; path = CurrencyText.xcworkspace; sourceTree = SOURCE_ROOT; };
+		OBJ_34 /* UICurrencyTextField.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = UICurrencyTextField.podspec; sourceTree = "<group>"; };
+		OBJ_35 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		OBJ_36 /* PULL_REQUEST_TEMPLATE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = PULL_REQUEST_TEMPLATE.md; sourceTree = "<group>"; };
+		OBJ_37 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		OBJ_38 /* ISSUE_TEMPLATE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = ISSUE_TEMPLATE.md; sourceTree = "<group>"; };
+		OBJ_39 /* CurrencyText.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = CurrencyText.podspec; sourceTree = "<group>"; };
+		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		OBJ_9 /* Currency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Currency.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		OBJ_50 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_76 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_77 /* CurrencyFormatter.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_89 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_90 /* CurrencyUITextFieldDelegate.framework in Frameworks */,
+				OBJ_91 /* CurrencyFormatter.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		OBJ_14 /* CurrencyUITextFieldDelegate */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_15 /* CurrencyUITextFieldDelegate.swift */,
+				OBJ_16 /* UITextField.swift */,
+			);
+			name = CurrencyUITextFieldDelegate;
+			path = Sources/UITextFieldDelegate;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_17 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_18 /* Tests */,
+			);
+			name = Tests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_18 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_19 /* CurrencyFormatter */,
+				OBJ_23 /* CurrencyText */,
+			);
+			path = Tests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_19 /* CurrencyFormatter */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_20 /* CurrencyFormatterTests.swift */,
+				OBJ_21 /* NumberFormatterTests.swift */,
+				OBJ_22 /* StringTests.swift */,
+			);
+			path = CurrencyFormatter;
+			sourceTree = "<group>";
+		};
+		OBJ_23 /* CurrencyText */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_24 /* CurrencyTextFieldDelegateTests.swift */,
+				OBJ_25 /* UITextField.swift */,
+				OBJ_26 /* UITextFieldTests.swift */,
+			);
+			path = CurrencyText;
+			sourceTree = "<group>";
+		};
+		OBJ_27 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				"CurrencyText::CurrencyFormatter::Product" /* CurrencyFormatter.framework */,
+				"CurrencyText::CurrencyUITextFieldDelegate::Product" /* CurrencyUITextFieldDelegate.framework */,
+				"CurrencyText::Tests::Product" /* Tests.xctest */,
+			);
+			name = Products;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		OBJ_5 = {
+			isa = PBXGroup;
+			children = (
+				OBJ_6 /* Package.swift */,
+				OBJ_7 /* Sources */,
+				OBJ_17 /* Tests */,
+				OBJ_27 /* Products */,
+				OBJ_31 /* images */,
+				OBJ_32 /* Example */,
+				OBJ_33 /* CurrencyText.xcworkspace */,
+				OBJ_34 /* UICurrencyTextField.podspec */,
+				OBJ_35 /* LICENSE */,
+				OBJ_36 /* PULL_REQUEST_TEMPLATE.md */,
+				OBJ_37 /* README.md */,
+				OBJ_38 /* ISSUE_TEMPLATE.md */,
+				OBJ_39 /* CurrencyText.podspec */,
+			);
+			sourceTree = "<group>";
+		};
+		OBJ_7 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_8 /* CurrencyFormatter */,
+				OBJ_14 /* CurrencyUITextFieldDelegate */,
+			);
+			name = Sources;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_8 /* CurrencyFormatter */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_9 /* Currency.swift */,
+				OBJ_10 /* CurrencyFormatter.swift */,
+				OBJ_11 /* CurrencyLocale.swift */,
+				OBJ_12 /* NumberFormatter.swift */,
+				OBJ_13 /* String.swift */,
+			);
+			name = CurrencyFormatter;
+			path = Sources/Formatter;
+			sourceTree = SOURCE_ROOT;
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		"CurrencyText::CurrencyFormatter" /* CurrencyFormatter */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_41 /* Build configuration list for PBXNativeTarget "CurrencyFormatter" */;
+			buildPhases = (
+				OBJ_44 /* Sources */,
+				OBJ_50 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CurrencyFormatter;
+			productName = CurrencyFormatter;
+			productReference = "CurrencyText::CurrencyFormatter::Product" /* CurrencyFormatter.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"CurrencyText::CurrencyUITextFieldDelegate" /* CurrencyUITextFieldDelegate */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_70 /* Build configuration list for PBXNativeTarget "CurrencyUITextFieldDelegate" */;
+			buildPhases = (
+				OBJ_73 /* Sources */,
+				OBJ_76 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_78 /* PBXTargetDependency */,
+			);
+			name = CurrencyUITextFieldDelegate;
+			productName = CurrencyUITextFieldDelegate;
+			productReference = "CurrencyText::CurrencyUITextFieldDelegate::Product" /* CurrencyUITextFieldDelegate.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"CurrencyText::SwiftPMPackageDescription" /* CurrencyTextPackageDescription */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_59 /* Build configuration list for PBXNativeTarget "CurrencyTextPackageDescription" */;
+			buildPhases = (
+				OBJ_62 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CurrencyTextPackageDescription;
+			productName = CurrencyTextPackageDescription;
+			productType = "com.apple.product-type.framework";
+		};
+		"CurrencyText::Tests" /* Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_79 /* Build configuration list for PBXNativeTarget "Tests" */;
+			buildPhases = (
+				OBJ_82 /* Sources */,
+				OBJ_89 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_92 /* PBXTargetDependency */,
+				OBJ_93 /* PBXTargetDependency */,
+			);
+			name = Tests;
+			productName = Tests;
+			productReference = "CurrencyText::Tests::Product" /* Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		OBJ_1 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftMigration = 9999;
+				LastUpgradeCheck = 9999;
+			};
+			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "CurrencyText" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = OBJ_5;
+			productRefGroup = OBJ_27 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				"CurrencyText::CurrencyFormatter" /* CurrencyFormatter */,
+				"CurrencyText::CurrencyText::ProductTarget" /* CurrencyText */,
+				"CurrencyText::SwiftPMPackageDescription" /* CurrencyTextPackageDescription */,
+				"CurrencyText::CurrencyTextPackageTests::ProductTarget" /* CurrencyTextPackageTests */,
+				"CurrencyText::CurrencyUITextFieldDelegate" /* CurrencyUITextFieldDelegate */,
+				"CurrencyText::Tests" /* Tests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		OBJ_44 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_45 /* Currency.swift in Sources */,
+				OBJ_46 /* CurrencyFormatter.swift in Sources */,
+				OBJ_47 /* CurrencyLocale.swift in Sources */,
+				OBJ_48 /* NumberFormatter.swift in Sources */,
+				OBJ_49 /* String.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_62 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_63 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_73 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_74 /* CurrencyUITextFieldDelegate.swift in Sources */,
+				OBJ_75 /* UITextField.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_82 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_83 /* CurrencyFormatterTests.swift in Sources */,
+				OBJ_84 /* NumberFormatterTests.swift in Sources */,
+				OBJ_85 /* StringTests.swift in Sources */,
+				OBJ_86 /* CurrencyTextFieldDelegateTests.swift in Sources */,
+				OBJ_87 /* UITextField.swift in Sources */,
+				OBJ_88 /* UITextFieldTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		OBJ_55 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "CurrencyText::CurrencyFormatter" /* CurrencyFormatter */;
+			targetProxy = C167D3EA23DBB6A8000DC9F3 /* PBXContainerItemProxy */;
+		};
+		OBJ_56 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "CurrencyText::CurrencyUITextFieldDelegate" /* CurrencyUITextFieldDelegate */;
+			targetProxy = C167D3EB23DBB6A8000DC9F3 /* PBXContainerItemProxy */;
+		};
+		OBJ_68 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "CurrencyText::Tests" /* Tests */;
+			targetProxy = C167D3E923DBB683000DC9F3 /* PBXContainerItemProxy */;
+		};
+		OBJ_78 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "CurrencyText::CurrencyFormatter" /* CurrencyFormatter */;
+			targetProxy = C167D3E623DBB682000DC9F3 /* PBXContainerItemProxy */;
+		};
+		OBJ_92 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "CurrencyText::CurrencyUITextFieldDelegate" /* CurrencyUITextFieldDelegate */;
+			targetProxy = C167D3E723DBB682000DC9F3 /* PBXContainerItemProxy */;
+		};
+		OBJ_93 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "CurrencyText::CurrencyFormatter" /* CurrencyFormatter */;
+			targetProxy = C167D3E823DBB682000DC9F3 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		OBJ_3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"SWIFT_PACKAGE=1",
+					"DEBUG=1",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_SWIFT_FLAGS = "$(inherited) -DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE DEBUG";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		OBJ_4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_OPTIMIZATION_LEVEL = s;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"SWIFT_PACKAGE=1",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_SWIFT_FLAGS = "$(inherited) -DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 5.0;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		OBJ_42 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = CurrencyText.xcodeproj/CurrencyFormatter_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = CurrencyFormatter;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = CurrencyFormatter;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_43 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = CurrencyText.xcodeproj/CurrencyFormatter_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = CurrencyFormatter;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = CurrencyFormatter;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		OBJ_53 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		OBJ_54 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		OBJ_60 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		OBJ_61 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		OBJ_66 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		OBJ_67 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		OBJ_71 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = CurrencyText.xcodeproj/CurrencyUITextFieldDelegate_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = CurrencyUITextFieldDelegate;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = CurrencyUITextFieldDelegate;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_72 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = CurrencyText.xcodeproj/CurrencyUITextFieldDelegate_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = CurrencyUITextFieldDelegate;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = CurrencyUITextFieldDelegate;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		OBJ_80 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = CurrencyText.xcodeproj/Tests_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = Tests;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_81 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = CurrencyText.xcodeproj/Tests_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = Tests;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		OBJ_2 /* Build configuration list for PBXProject "CurrencyText" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_3 /* Debug */,
+				OBJ_4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_41 /* Build configuration list for PBXNativeTarget "CurrencyFormatter" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_42 /* Debug */,
+				OBJ_43 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_52 /* Build configuration list for PBXAggregateTarget "CurrencyText" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_53 /* Debug */,
+				OBJ_54 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_59 /* Build configuration list for PBXNativeTarget "CurrencyTextPackageDescription" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_60 /* Debug */,
+				OBJ_61 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_65 /* Build configuration list for PBXAggregateTarget "CurrencyTextPackageTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_66 /* Debug */,
+				OBJ_67 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_70 /* Build configuration list for PBXNativeTarget "CurrencyUITextFieldDelegate" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_71 /* Debug */,
+				OBJ_72 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_79 /* Build configuration list for PBXNativeTarget "Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_80 /* Debug */,
+				OBJ_81 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = OBJ_1 /* Project object */;
 }

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		7606859CC2958C971102F500 /* Pods_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 978CFBD655B243A245601F7E /* Pods_Example.framework */; };
+		C58319C3261583FBD4501926 /* Pods_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A8A6AA780524A7622A9E90F6 /* Pods_Example.framework */; };
 		D54170DA209023D5008995D7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D54170D9209023D5008995D7 /* AppDelegate.swift */; };
 		D54170DC209023D5008995D7 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D54170DB209023D5008995D7 /* ViewController.swift */; };
 		D54170DF209023D5008995D7 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D54170DD209023D5008995D7 /* Main.storyboard */; };
@@ -16,9 +16,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		518E8343A17679893337F5CA /* Pods-Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.debug.xcconfig"; path = "Target Support Files/Pods-Example/Pods-Example.debug.xcconfig"; sourceTree = "<group>"; };
-		530FF63F62F6E6995B19F045 /* Pods-Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.release.xcconfig"; path = "Target Support Files/Pods-Example/Pods-Example.release.xcconfig"; sourceTree = "<group>"; };
-		978CFBD655B243A245601F7E /* Pods_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5C98B736202C58BF0F533381 /* Pods-Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.debug.xcconfig"; path = "Target Support Files/Pods-Example/Pods-Example.debug.xcconfig"; sourceTree = "<group>"; };
+		7393A3F93E6AD12D2FB7088A /* Pods-Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.release.xcconfig"; path = "Target Support Files/Pods-Example/Pods-Example.release.xcconfig"; sourceTree = "<group>"; };
+		A8A6AA780524A7622A9E90F6 /* Pods_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D54170D6209023D5008995D7 /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D54170D9209023D5008995D7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D54170DB209023D5008995D7 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -33,17 +33,17 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7606859CC2958C971102F500 /* Pods_Example.framework in Frameworks */,
+				C58319C3261583FBD4501926 /* Pods_Example.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		4B0924BF86E53AF6668D45B5 /* Frameworks */ = {
+		80BE38F37E37D45D91B2E42D /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				978CFBD655B243A245601F7E /* Pods_Example.framework */,
+				A8A6AA780524A7622A9E90F6 /* Pods_Example.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -51,8 +51,8 @@
 		CFE5CB0773053BF416CDB872 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				518E8343A17679893337F5CA /* Pods-Example.debug.xcconfig */,
-				530FF63F62F6E6995B19F045 /* Pods-Example.release.xcconfig */,
+				5C98B736202C58BF0F533381 /* Pods-Example.debug.xcconfig */,
+				7393A3F93E6AD12D2FB7088A /* Pods-Example.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -63,7 +63,7 @@
 				D54170D8209023D5008995D7 /* Example */,
 				D54170D7209023D5008995D7 /* Products */,
 				CFE5CB0773053BF416CDB872 /* Pods */,
-				4B0924BF86E53AF6668D45B5 /* Frameworks */,
+				80BE38F37E37D45D91B2E42D /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -95,11 +95,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = D54170FE209023D8008995D7 /* Build configuration list for PBXNativeTarget "Example" */;
 			buildPhases = (
-				E7049CC37F461C3FCF691C98 /* [CP] Check Pods Manifest.lock */,
+				A80AA75944179636BCE7A750 /* [CP] Check Pods Manifest.lock */,
 				D54170D2209023D5008995D7 /* Sources */,
 				D54170D3209023D5008995D7 /* Frameworks */,
 				D54170D4209023D5008995D7 /* Resources */,
-				77087F178403C86BC5410314 /* [CP] Embed Pods Frameworks */,
+				90A6C104174FCB6067E37AC4 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -158,7 +158,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		77087F178403C86BC5410314 /* [CP] Embed Pods Frameworks */ = {
+		90A6C104174FCB6067E37AC4 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -175,7 +175,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Example/Pods-Example-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E7049CC37F461C3FCF691C98 /* [CP] Check Pods Manifest.lock */ = {
+		A80AA75944179636BCE7A750 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -349,7 +349,7 @@
 		};
 		D54170FF209023D8008995D7 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 518E8343A17679893337F5CA /* Pods-Example.debug.xcconfig */;
+			baseConfigurationReference = 5C98B736202C58BF0F533381 /* Pods-Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
@@ -362,14 +362,14 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.felipemarino.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
 		D5417100209023D8008995D7 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 530FF63F62F6E6995B19F045 /* Pods-Example.release.xcconfig */;
+			baseConfigurationReference = 7393A3F93E6AD12D2FB7088A /* Pods-Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
@@ -382,7 +382,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.felipemarino.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Example/Example/Base.lproj/Main.storyboard
+++ b/Example/Example/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -13,60 +13,306 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" adjustsFontSizeToFit="NO" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="qkW-Y1-m4o">
-                                <rect key="frame" x="50" y="100" width="275" height="50"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="50" id="4KN-T7-v2j"/>
-                                </constraints>
-                                <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="25"/>
-                                <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
-                            </textField>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="4 integers set up" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I3m-95-Uoa">
-                                <rect key="frame" x="94.5" y="60.5" width="186.5" height="31.5"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="26"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Value without formatting" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fMB-mB-boF">
-                                <rect key="frame" x="81.5" y="190" width="212" height="24"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Value with formatting" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2r1-l2-upc">
-                                <rect key="frame" x="95.5" y="158" width="184" height="24"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Cp5-dN-dA6">
+                                <rect key="frame" x="40" y="44" width="334" height="664"/>
+                                <subviews>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" adjustsFontSizeToFit="NO" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="qkW-Y1-m4o">
+                                        <rect key="frame" x="0.0" y="0.0" width="334" height="44"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="4KN-T7-v2j"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="25"/>
+                                        <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
+                                    </textField>
+                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="kpI-GY-j03">
+                                        <rect key="frame" x="66.333333333333329" y="52" width="201.66666666666669" height="24"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="unformatted" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2r1-l2-upc">
+                                                <rect key="frame" x="0.0" y="0.0" width="106.66666666666667" height="24"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="formatted" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fMB-mB-boF">
+                                                <rect key="frame" x="116.66666666666669" y="0.0" width="85" height="24"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" adjustsFontSizeToFit="NO" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="lhe-Xa-7ZE">
+                                        <rect key="frame" x="0.0" y="84" width="334" height="44"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="0yn-3q-9MS"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="25"/>
+                                        <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
+                                    </textField>
+                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="1Y9-HG-v3N">
+                                        <rect key="frame" x="66.333333333333329" y="136" width="201.66666666666669" height="24"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="unformatted" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QS8-0l-aKu">
+                                                <rect key="frame" x="0.0" y="0.0" width="106.66666666666667" height="24"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="formatted" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KC3-6p-lTF">
+                                                <rect key="frame" x="116.66666666666669" y="0.0" width="85" height="24"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" adjustsFontSizeToFit="NO" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="RQN-IY-z2C">
+                                        <rect key="frame" x="0.0" y="168" width="334" height="44"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="kA5-Ms-eBQ"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="25"/>
+                                        <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
+                                    </textField>
+                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="PBh-LG-9G6">
+                                        <rect key="frame" x="66.333333333333329" y="220" width="201.66666666666669" height="24"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="unformatted" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pVK-0X-pex">
+                                                <rect key="frame" x="0.0" y="0.0" width="106.66666666666667" height="24"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="formatted" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XhY-5U-db4">
+                                                <rect key="frame" x="116.66666666666669" y="0.0" width="85" height="24"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" adjustsFontSizeToFit="NO" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="lhB-iY-x0F">
+                                        <rect key="frame" x="0.0" y="252" width="334" height="44"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="NyS-uO-OTR"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="25"/>
+                                        <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
+                                    </textField>
+                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="HGo-5D-OJ9">
+                                        <rect key="frame" x="66.333333333333329" y="304" width="201.66666666666669" height="24"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="unformatted" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kQx-Ft-KcI">
+                                                <rect key="frame" x="0.0" y="0.0" width="106.66666666666667" height="24"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="formatted" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fu8-T6-Mz7">
+                                                <rect key="frame" x="116.66666666666669" y="0.0" width="85" height="24"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" adjustsFontSizeToFit="NO" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="kRP-hG-oqz">
+                                        <rect key="frame" x="0.0" y="336" width="334" height="44"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="rKF-Is-8YO"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="25"/>
+                                        <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
+                                    </textField>
+                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="iTz-a5-mPI">
+                                        <rect key="frame" x="66.333333333333329" y="388" width="201.66666666666669" height="24"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="unformatted" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="94Q-Fp-YU8">
+                                                <rect key="frame" x="0.0" y="0.0" width="106.66666666666667" height="24"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="formatted" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dgE-Lu-jQh">
+                                                <rect key="frame" x="116.66666666666669" y="0.0" width="85" height="24"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" adjustsFontSizeToFit="NO" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="lxJ-ZK-vS1">
+                                        <rect key="frame" x="0.0" y="420" width="334" height="44"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="F8i-XF-fmZ"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="25"/>
+                                        <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
+                                    </textField>
+                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="mKB-KF-zcH">
+                                        <rect key="frame" x="66.333333333333329" y="472" width="201.66666666666669" height="24"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="unformatted" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DeJ-PT-SFx">
+                                                <rect key="frame" x="0.0" y="0.0" width="106.66666666666667" height="24"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="formatted" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bSC-ML-j20">
+                                                <rect key="frame" x="116.66666666666669" y="0.0" width="85" height="24"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" adjustsFontSizeToFit="NO" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ffJ-t2-0cG">
+                                        <rect key="frame" x="0.0" y="504" width="334" height="44"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="9E3-Z8-JvC"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="25"/>
+                                        <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
+                                    </textField>
+                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="qgp-xb-Ng2">
+                                        <rect key="frame" x="66.333333333333329" y="556" width="201.66666666666669" height="24"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="unformatted" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AYt-yW-IEj">
+                                                <rect key="frame" x="0.0" y="0.0" width="106.66666666666667" height="24"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="formatted" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Td-sM-7lF">
+                                                <rect key="frame" x="116.66666666666669" y="0.0" width="85" height="24"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" adjustsFontSizeToFit="NO" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="9FD-XW-ZUh">
+                                        <rect key="frame" x="0.0" y="588" width="334" height="44"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="1LB-xR-dpv"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="25"/>
+                                        <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
+                                    </textField>
+                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="7Nz-Mx-nj9">
+                                        <rect key="frame" x="66.333333333333329" y="640" width="201.66666666666669" height="24"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="unformatted" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dd9-im-RFI">
+                                                <rect key="frame" x="0.0" y="0.0" width="106.66666666666667" height="24"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="formatted" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pXt-eU-9Lb">
+                                                <rect key="frame" x="116.66666666666669" y="0.0" width="85" height="24"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="qkW-Y1-m4o" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="50" id="1WU-oD-Qeb"/>
-                            <constraint firstItem="2r1-l2-upc" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="2WV-nU-pXz"/>
-                            <constraint firstItem="qkW-Y1-m4o" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="Aao-me-7ob"/>
-                            <constraint firstItem="fMB-mB-boF" firstAttribute="top" secondItem="2r1-l2-upc" secondAttribute="bottom" constant="8" id="Nam-oV-YhV"/>
-                            <constraint firstItem="I3m-95-Uoa" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="P3v-T0-m42"/>
-                            <constraint firstItem="qkW-Y1-m4o" firstAttribute="top" secondItem="I3m-95-Uoa" secondAttribute="bottom" constant="8" id="RXx-9q-fH0"/>
-                            <constraint firstItem="qkW-Y1-m4o" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="100" id="bZU-F7-lCz"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="qkW-Y1-m4o" secondAttribute="trailing" constant="50" id="dMd-Fw-yo0"/>
-                            <constraint firstItem="2r1-l2-upc" firstAttribute="top" secondItem="qkW-Y1-m4o" secondAttribute="bottom" constant="8" id="fiW-QJ-5y8"/>
-                            <constraint firstItem="fMB-mB-boF" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="gPb-yv-eHV"/>
+                            <constraint firstItem="9FD-XW-ZUh" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" constant="-80" id="2qn-sQ-B3u"/>
+                            <constraint firstItem="lxJ-ZK-vS1" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" constant="-80" id="85X-ST-9fL"/>
+                            <constraint firstItem="Cp5-dN-dA6" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="H9E-KK-Ve5"/>
+                            <constraint firstItem="Cp5-dN-dA6" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="b8y-08-Y1c"/>
+                            <constraint firstItem="RQN-IY-z2C" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" constant="-80" id="f5F-kR-N44"/>
+                            <constraint firstItem="lhB-iY-x0F" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" constant="-80" id="gy1-PL-ytl"/>
+                            <constraint firstItem="ffJ-t2-0cG" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" constant="-80" id="hWY-73-X4V"/>
+                            <constraint firstItem="lhe-Xa-7ZE" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" constant="-80" id="iXd-6V-8TK"/>
+                            <constraint firstItem="kRP-hG-oqz" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" constant="-80" id="xG6-Hd-qaC"/>
+                            <constraint firstItem="qkW-Y1-m4o" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" constant="-80" id="yfg-NX-vmZ"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <connections>
-                        <outlet property="formattedLabel" destination="2r1-l2-upc" id="DTj-47-7sS"/>
-                        <outlet property="textField" destination="qkW-Y1-m4o" id="MyP-Cx-6AS"/>
-                        <outlet property="unformattedLabel" destination="fMB-mB-boF" id="sPW-AC-7GD"/>
+                        <outlet property="dollarFieldDecimalEditing" destination="2Bn-2w-OIQ" id="8C7-gv-032"/>
+                        <outlet property="dollarFieldDecimalNew" destination="W3a-ar-itv" id="rzs-9q-WWw"/>
+                        <outlet property="dollarFieldEditing" destination="6T6-c9-Eiy" id="Ut4-9l-W5V"/>
+                        <outlet property="dollarFieldNew" destination="nJg-qo-nSm" id="wLg-or-Yet"/>
+                        <outlet property="euroFieldDecimalEditing" destination="FHi-7Q-jkz" id="bnQ-60-2ao"/>
+                        <outlet property="euroFieldDecimalNew" destination="f0J-5x-DV8" id="lTd-tH-DzY"/>
+                        <outlet property="euroFieldEditing" destination="R8T-wi-zgd" id="o7Y-dl-0wQ"/>
+                        <outlet property="euroFieldNew" destination="eNy-oU-axE" id="lgS-Ha-uAX"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+                <customObject id="eNy-oU-axE" userLabel="Euro Field Display New" customClass="FieldDisplay" customModule="Example" customModuleProvider="target">
+                    <connections>
+                        <outlet property="formattedLabel" destination="fMB-mB-boF" id="Fxh-ag-Wyh"/>
+                        <outlet property="textField" destination="qkW-Y1-m4o" id="v4g-ZZ-4kz"/>
+                        <outlet property="unformattedLabel" destination="2r1-l2-upc" id="dqL-Of-RIU"/>
+                    </connections>
+                </customObject>
+                <customObject id="R8T-wi-zgd" userLabel="Euro Field Display Editing" customClass="FieldDisplay" customModule="Example" customModuleProvider="target">
+                    <connections>
+                        <outlet property="formattedLabel" destination="KC3-6p-lTF" id="Eb1-nw-dUz"/>
+                        <outlet property="textField" destination="lhe-Xa-7ZE" id="qbn-cP-IL5"/>
+                        <outlet property="unformattedLabel" destination="QS8-0l-aKu" id="P1R-Ew-KWd"/>
+                    </connections>
+                </customObject>
+                <customObject id="f0J-5x-DV8" userLabel="Euro Field Decimal Display New" customClass="FieldDisplay" customModule="Example" customModuleProvider="target">
+                    <connections>
+                        <outlet property="formattedLabel" destination="XhY-5U-db4" id="Vtb-Ra-hrZ"/>
+                        <outlet property="textField" destination="RQN-IY-z2C" id="1u7-8W-epd"/>
+                        <outlet property="unformattedLabel" destination="pVK-0X-pex" id="mg9-Nd-pVH"/>
+                    </connections>
+                </customObject>
+                <customObject id="FHi-7Q-jkz" userLabel="Euro Field Decimal Display Editing" customClass="FieldDisplay" customModule="Example" customModuleProvider="target">
+                    <connections>
+                        <outlet property="formattedLabel" destination="fu8-T6-Mz7" id="bsP-Xd-Nj9"/>
+                        <outlet property="textField" destination="lhB-iY-x0F" id="Xzs-TY-xdF"/>
+                        <outlet property="unformattedLabel" destination="kQx-Ft-KcI" id="l3y-B5-6Kt"/>
+                    </connections>
+                </customObject>
+                <customObject id="nJg-qo-nSm" userLabel="Dollar Field Display New" customClass="FieldDisplay" customModule="Example" customModuleProvider="target">
+                    <connections>
+                        <outlet property="formattedLabel" destination="dgE-Lu-jQh" id="2eZ-Up-rkP"/>
+                        <outlet property="textField" destination="kRP-hG-oqz" id="buc-nm-ckY"/>
+                        <outlet property="unformattedLabel" destination="94Q-Fp-YU8" id="HUU-WQ-R0Z"/>
+                    </connections>
+                </customObject>
+                <customObject id="6T6-c9-Eiy" userLabel="Dollar Field Display Editing" customClass="FieldDisplay" customModule="Example" customModuleProvider="target">
+                    <connections>
+                        <outlet property="formattedLabel" destination="bSC-ML-j20" id="VMR-j0-isw"/>
+                        <outlet property="textField" destination="lxJ-ZK-vS1" id="eJk-e7-X9l"/>
+                        <outlet property="unformattedLabel" destination="DeJ-PT-SFx" id="4Om-sn-L1N"/>
+                    </connections>
+                </customObject>
+                <customObject id="W3a-ar-itv" userLabel="Dollar Field Decimal Display New" customClass="FieldDisplay" customModule="Example" customModuleProvider="target">
+                    <connections>
+                        <outlet property="formattedLabel" destination="6Td-sM-7lF" id="Nto-Vi-usT"/>
+                        <outlet property="textField" destination="ffJ-t2-0cG" id="gzD-nN-Jsl"/>
+                        <outlet property="unformattedLabel" destination="AYt-yW-IEj" id="wdu-fD-l75"/>
+                    </connections>
+                </customObject>
+                <customObject id="2Bn-2w-OIQ" userLabel="Dollar Field Decimal Display Editing" customClass="FieldDisplay" customModule="Example" customModuleProvider="target">
+                    <connections>
+                        <outlet property="formattedLabel" destination="pXt-eU-9Lb" id="JVC-f3-AbT"/>
+                        <outlet property="textField" destination="9FD-XW-ZUh" id="LfL-Gg-3C5"/>
+                        <outlet property="unformattedLabel" destination="Dd9-im-RFI" id="yUu-pE-dLX"/>
+                    </connections>
+                </customObject>
             </objects>
             <point key="canvasLocation" x="138" y="133"/>
         </scene>

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -14,26 +14,18 @@ import CurrencyText
 ///
 /// If you are using CocoaPods you are able to import both `CurrencyText` and the subspecs mentioned above.
 
-class ViewController: UIViewController {
-
+class FieldDisplay: NSObject {
     @IBOutlet weak private var textField: UITextField!
     @IBOutlet weak private var formattedLabel: UILabel!
     @IBOutlet weak private var unformattedLabel: UILabel!
-
     private var textFieldDelegate: CurrencyUITextFieldDelegate!
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        setupTextFieldWithCurrencyDelegate()
-    }
-    
-    private func setupTextFieldWithCurrencyDelegate() {
+    fileprivate func setupCurrencyDelegate(currency: CurrencyText.Currency, locale: CurrencyText.CurrencyLocale) {
         let currencyFormatter = CurrencyFormatter {
             $0.maxValue = 100000000
             $0.minValue = 1
-            $0.currency = .dollar
-            $0.locale = CurrencyLocale.englishUnitedStates
+            $0.currency = currency
+            $0.locale = locale
             $0.hasDecimals = false
         }
         
@@ -45,6 +37,64 @@ class ViewController: UIViewController {
         textField.keyboardType = .numbersAndPunctuation
     }
     
+    fileprivate func setupDecimalMode() {
+        let formatter = textFieldDelegate.formatter as! CurrencyFormatter
+        formatter.hasDecimals = true
+    }
+    
+    fileprivate func setupEditingText() {
+        guard let formatter = textFieldDelegate.formatter as? CurrencyFormatter else { return }
+        let initialText = formatter.hasDecimals ? "123456.78" : "123456"
+        textField.text = formatter.updated(formattedString: initialText)
+    }
+
+}
+
+extension FieldDisplay: UITextFieldDelegate {
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        formattedLabel.text = textField.text
+        unformattedLabel.text = textFieldDelegate.formatter.unformatted(string: textField.text ?? "0")
+    }
+}
+    
+
+class ViewController: UIViewController {
+
+    @IBOutlet weak private var euroFieldNew: FieldDisplay!
+    @IBOutlet weak private var euroFieldEditing: FieldDisplay!
+    @IBOutlet weak private var euroFieldDecimalNew: FieldDisplay!
+    @IBOutlet weak private var euroFieldDecimalEditing: FieldDisplay!
+
+    @IBOutlet weak private var dollarFieldNew: FieldDisplay!
+    @IBOutlet weak private var dollarFieldEditing: FieldDisplay!
+    @IBOutlet weak private var dollarFieldDecimalNew: FieldDisplay!
+    @IBOutlet weak private var dollarFieldDecimalEditing: FieldDisplay!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.view.isUserInteractionEnabled = true
+        
+        euroFieldNew.setupCurrencyDelegate(currency: .euro, locale: .french)
+        euroFieldEditing.setupCurrencyDelegate(currency: .euro, locale: .french)
+        euroFieldDecimalNew.setupCurrencyDelegate(currency: .euro, locale: .french)
+        euroFieldDecimalNew.setupDecimalMode()
+        euroFieldDecimalEditing.setupCurrencyDelegate(currency: .euro, locale: .french)
+        euroFieldDecimalEditing.setupDecimalMode()
+        
+        dollarFieldNew.setupCurrencyDelegate(currency: .dollar, locale: .englishUnitedStates)
+        dollarFieldEditing.setupCurrencyDelegate(currency: .dollar, locale: .englishUnitedStates)
+        dollarFieldDecimalNew.setupCurrencyDelegate(currency: .dollar, locale: .englishUnitedStates)
+        dollarFieldDecimalNew.setupDecimalMode()
+        dollarFieldDecimalEditing.setupCurrencyDelegate(currency: .dollar, locale: .englishUnitedStates)
+        dollarFieldDecimalEditing.setupDecimalMode()
+
+        euroFieldEditing.setupEditingText()
+        euroFieldDecimalEditing.setupEditingText()
+        dollarFieldEditing.setupEditingText()
+        dollarFieldDecimalEditing.setupEditingText()
+    }
+    
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         resignAnyFirstReponder()
     }
@@ -54,9 +104,4 @@ class ViewController: UIViewController {
     }
 }
 
-extension ViewController: UITextFieldDelegate {
-    func textFieldDidEndEditing(_ textField: UITextField) {
-        formattedLabel.text = textField.text
-        unformattedLabel.text = textFieldDelegate.formatter.unformatted(string: textField.text ?? "0")
-    }
-}
+


### PR DESCRIPTION
New fields begin with no contents, and editing fields begin with some content to be edited.

### Why?
Help us better see how the field reacts in multiple currencies and field configurations all at once.

### Changes
Added 5 text fields in various configurations of initial values to just the example app.

### Tests 
Run the example app.

### [Issue]() (optional) add link to the issue here
All fields that do not contain initial values, but also have decimal values configured, where hasDecimal is set true, misbehave when the user types "1" then "2" in those fields.

In Euros the value result is "10,02 €".  The expected result is "0,12 €".
In Dollars the value result is "$10.02".  In Dollars the value result is "$0.12"

So far I haven't noticed any other problems with editing or cursor.

