### PR TITLE
Send editingChanged from shouldChangeCharactersIn

### DIFF
--- a/Sources/UITextFieldDelegate/CurrencyUITextFieldDelegate.swift
+++ b/Sources/UITextFieldDelegate/CurrencyUITextFieldDelegate.swift
@@ -92,6 +92,7 @@ extension CurrencyUITextFieldDelegate: UITextFieldDelegate {
         // respecting previous selected text range offset from end.
         defer {
             textField.updateSelectedTextRange(lastOffsetFromEnd: lastSelectedTextRangeOffsetFromEnd)
+            textField.sendActions(for: .editingChanged)
         }
 
         let returnAndCallPassThroughDelegate: () -> Bool = {


### PR DESCRIPTION
### Why?
Text was set manually in the `shouldChangeCharactersIn` and it didn't trigger `editingChanged` method.

### Changes
Send `editingChanged` from `shouldChangeCharactersIn`.