### PR TITLE
Fix formatter to be correctly updated on Swift UI

### DIFF
--- a/Sources/SwiftUI/WrappedTextField.swift
+++ b/Sources/SwiftUI/WrappedTextField.swift
@@ -42,6 +42,7 @@ final class WrappedTextField: UITextField {
         guard configuration !== self.configuration else { return }
 
         self.configuration = configuration
+        self.currencyTextFieldDelegate.formatter = configuration.formatter
     }
 
     func updateTextIfNeeded() {


### PR DESCRIPTION
### Why?
#87 

### Changes
Fix `WrappedTextFiled` to update the formatter when `updateConfigurationIfNeeded` gets called.
This aims to ensure `SwiftUI` updates have an effect on formatter changes.

### Tests 
Added a test to cover the scenario