### PR TITLE
Feature/formatter binding

### DIFF
--- a/Sources/CurrencyTextFieldTestSupport/Fixtures/Fixtures+CurrencyTextFieldConfiguration.swift
+++ b/Sources/CurrencyTextFieldTestSupport/Fixtures/Fixtures+CurrencyTextFieldConfiguration.swift
@@ -36,7 +36,10 @@ public extension CurrencyTextFieldConfiguration {
             set: { _ in }
         ),
         clearsWhenValueIsZero: Bool = true,
-        formatter: CurrencyFormatter = .init(),
+        formatter: Binding<CurrencyFormatter> = .init(
+            get: { .init() },
+            set: { _ in }
+        ),
         textFieldConfiguration: ((UITextField) -> Void)? = { _ in },
         onEditingChanged: ((Bool) -> Void)? = { _ in },
         onCommit: (() -> Void)? = { }

--- a/Sources/Formatter/Currency.swift
+++ b/Sources/Formatter/Currency.swift
@@ -12,7 +12,7 @@ import Foundation
 /// composed of a country’s two-character Internet country code plus an extra character
 /// to denote the currency unit. For example, the currency code for the Australian
 /// dollar is “AUD”. Currency codes are based on the ISO 4217 standard
-public enum Currency: String {
+public enum Currency: String, CaseIterable {
     case afghani = "AFN",
     algerianDinar = "DZD",
     argentinePeso = "ARS",

--- a/Sources/Formatter/CurrencyLocale.swift
+++ b/Sources/Formatter/CurrencyLocale.swift
@@ -23,7 +23,7 @@ extension Locale: LocaleConvertible {
 }
 
 /// Defines locales available in system
-public enum CurrencyLocale: String, LocaleConvertible {
+public enum CurrencyLocale: String, LocaleConvertible, CaseIterable {
     
     case current = "current"
     case autoUpdating = "currentAutoUpdating"

--- a/Sources/SwiftUI/CurrencyTextFieldConfiguration.swift
+++ b/Sources/SwiftUI/CurrencyTextFieldConfiguration.swift
@@ -33,7 +33,8 @@ public final class CurrencyTextFieldConfiguration {
 
     let clearsWhenValueIsZero: Bool
 
-    let formatter: CurrencyFormatter
+    @Binding
+    var formatter: CurrencyFormatter
 
     let onCommit: (() -> Void)?
 
@@ -46,8 +47,8 @@ public final class CurrencyTextFieldConfiguration {
     /// - Parameters:
     ///   - text: The text to display and edit.
     ///   - hasFocus: Binding property to keep track and drive UITextField responder state.
-    ///   - formatter: Currency formatter instance that will be used by the TextField. It holds all formatting related settings, such
-    ///   as currency, locale, hasDecimals, etc,
+    ///   - formatter: Currency formatter binding that will be used by the TextField. It holds all formatting related settings, such
+    ///   as currency, locale, hasDecimals, etc, and propagates formatting updates.
     /// - Returns: Initialized instance of `CurrencyTextFieldConfiguration`.
     ///
     /// - note: Only text and formatter are set. When additional configurations are needed, like performing actions on text field
@@ -55,7 +56,7 @@ public final class CurrencyTextFieldConfiguration {
     public static func makeDefault(
         text: Binding<String>,
         hasFocus: Binding<Bool?>? = nil,
-        formatter: CurrencyFormatter
+        formatter: Binding<CurrencyFormatter>
     ) -> Self {
         .init(
             text: text,
@@ -77,8 +78,8 @@ public final class CurrencyTextFieldConfiguration {
     ///   - hasFocus: Binding property to keep track and drive UITextField responder state.
     ///   - clearsWhenValueIsZero: When `true` the text field text is cleared when user finishes editing with value as zero,
     ///   otherwise if `false` the text field text will keep it's text when value is zero.
-    ///   - formatter: Currency formatter instance that will be used by the TextField. It holds all formatting related settings, such
-    ///   as currency, locale, hasDecimals, etc.
+    ///   - formatter: Currency formatter binding that will be used by the TextField. It holds all formatting related settings, such
+    ///   as currency, locale, hasDecimals, etc, and propagates formatting updates.
     ///   - textFieldConfiguration: Closure to `configure the underlying UITextField`.
     ///   Unfortunately, so far, for many things there are no APIs provided by Apple to go from SwiftUI to UIKit,
     ///   like conversion of Font to UIFont. This configuration block allows the user to configure
@@ -99,7 +100,7 @@ public final class CurrencyTextFieldConfiguration {
         inputAmount: Binding<Double?>? = nil,
         hasFocus: Binding<Bool?>? = nil,
         clearsWhenValueIsZero: Bool = false,
-        formatter: CurrencyFormatter,
+        formatter: Binding<CurrencyFormatter>,
         textFieldConfiguration: ((UITextField) -> Void)?,
         onEditingChanged: ((Bool) -> Void)? = nil,
         onCommit: (() -> Void)? = nil
@@ -109,7 +110,7 @@ public final class CurrencyTextFieldConfiguration {
         self.unformattedText = unformattedText
         self.inputAmount = inputAmount
         self.hasFocus = hasFocus
-        self.formatter = formatter
+        self._formatter = formatter
         self.clearsWhenValueIsZero = clearsWhenValueIsZero
         self.onEditingChanged = onEditingChanged
         self.onCommit = onCommit

--- a/Sources/SwiftUI/WrappedTextField.swift
+++ b/Sources/SwiftUI/WrappedTextField.swift
@@ -46,7 +46,16 @@ final class WrappedTextField: UITextField {
     }
 
     func updateTextIfNeeded() {
-        guard configuration.text != text else { return }
+        var updatedText: String?
+        if let text = text, text.isEmpty == false {
+            updatedText = configuration
+                .formatter
+                .formattedStringWithAdjustedDecimalSeparator(from: text)
+        }
+
+        guard configuration.text != text || (updatedText != text && text?.isEmpty == false) else {
+            return
+        }
 
         updateText()
     }

--- a/Tests/SwiftUI/CurrencyTextFieldConfigurationTests.swift
+++ b/Tests/SwiftUI/CurrencyTextFieldConfigurationTests.swift
@@ -28,7 +28,10 @@ final class CurrencyTextFieldConfigurationTests: XCTestCase {
         let sut = CurrencyTextFieldConfiguration.makeDefault(
             text: textBinding,
             hasFocus: hasFocusBinding,
-            formatter: formatter
+            formatter: .init(
+                get: { formatter },
+                set: { _ in }
+            )
         )
 
         XCTAssertEqual(sut.placeholder, "")
@@ -45,7 +48,12 @@ final class CurrencyTextFieldConfigurationTests: XCTestCase {
 
     func testInit() {
         let formatter = CurrencyFormatter()
-        let sut = CurrencyTextFieldConfiguration.makeFixture(formatter: formatter)
+        let sut = CurrencyTextFieldConfiguration.makeFixture(
+            formatter: .init(
+                get: { formatter },
+                set: { _ in }
+            )
+        )
 
         XCTAssertEqual(sut.placeholder, "some")
         XCTAssertEqual(sut.text, "text")

--- a/Tests/SwiftUISnapshotTests/CurrencyTextFieldSnapshotTests.swift
+++ b/Tests/SwiftUISnapshotTests/CurrencyTextFieldSnapshotTests.swift
@@ -32,7 +32,10 @@ final class CurrencyTextFieldSnapshotTests: XCTestCase {
             let sut = CurrencyTextField(
                 configuration: .makeFixture(
                     textBinding: $fakeViewModel.text,
-                    formatter: testCase.formatter
+                    formatter: .init(
+                        get: { testCase.formatter },
+                        set: { _ in }
+                    )
                 )
             ).frame(width: 300, height: 80)
 
@@ -49,7 +52,10 @@ final class CurrencyTextFieldSnapshotTests: XCTestCase {
         let sut = CurrencyTextField(
             configuration: .makeFixture(
                 textBinding: $fakeViewModel.text,
-                formatter: CurrencyFormatter.TestCase.withDecimals.formatter,
+                formatter: .init(
+                    get: { CurrencyFormatter.TestCase.withDecimals.formatter },
+                    set: { _ in }
+                ),
                 textFieldConfiguration: { textField in
                     textField.borderStyle = .roundedRect
                     textField.textAlignment = .center


### PR DESCRIPTION
### Why?
Trying to fully resolve #87 

### Changes
**Breaking**: Make the formatter a `Binding` property on `CurrencyTextFieldConfiguration`, so changing it propagates an update on `SwiftUI` and then on updating the `CurrencyTextField` content.

### WIP
- Still evaluating and testing the changes
- Evaluating making bits of `CurrencyFormatter` Bindings in isolation, which would require a more complex update of the library and might be avoided at this moment

### Tests 
Tests updated to cover the scenario